### PR TITLE
 More addon options available

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -56,13 +56,21 @@
           "password": "str?"
         },
         "conf": {
+          "alarmexpectedactivity": "str?",
+          "alarmshell": "str?",
+          "alarmtimeout": "str?",
           "loglevel": "str",
           "device": "str",
           "donotprobe": "str?",
           "logtelegrams": "bool?",
           "format": "str",
           "logfile": "str",
-          "shell": "str"
+          "shell": "str",
+          "meterfiles": "str?",
+          "meterfilesaction": "list(overwrite|append)?",
+          "meterfilesnaming": "list(name|id|name-id)?",
+          "meterfilestimestamp": "list(never|day|hour|minute|micros)?",
+          "ignoreduplicates": "bool?"
         },
         "meters": [
           {


### PR DESCRIPTION
According to the [doc](https://github.com/weetmuts/wmbusmeters/blob/master/README.md#running-without-config-files-good-for-experimentation-and-test), added some options optional