### PR TITLE
Device and dontprobe arrays

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -58,7 +58,7 @@
         "conf": {
           "loglevel": "str",
           "device": [ "str" ],
-          "donotprobe": [ "str" ],
+          "donotprobe": [ "str?" ],
           "logtelegrams": "bool?",
           "format": "str",
           "logfile": "str",

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -31,8 +31,8 @@
         "enable_mqtt_discovery": false,
         "conf": {
             "loglevel": "normal",
-            "device": "auto:t1",
-            "donotprobe": "/dev/ttyAMA0",
+            "device": [ "auto:t1" ],
+            "donotprobe": [ "/dev/ttyAMA0" ],
             "logtelegrams": false,
             "format": "json",
             "logfile": "/dev/stdout",
@@ -57,8 +57,8 @@
         },
         "conf": {
           "loglevel": "str",
-          "device": "str",
-          "donotprobe": "str?",
+          "device": [ "str" ],
+          "donotprobe": [ "str" ],
           "logtelegrams": "bool?",
           "format": "str",
           "logfile": "str",


### PR DESCRIPTION
The last HA addon update broke our use case; we have two dongles, each listening on a different frequency. This PR changes the `device` and `dontprobe` config fields to be be arrays