### PR TITLE
lansenth driver: parse temperature as AutoSigned in order to see negative values

### DIFF
--- a/src/driver_lansenth.cc
+++ b/src/driver_lansenth.cc
@@ -75,7 +75,7 @@ namespace
              "The average temperature over the last hour.",
              DEFAULT_PRINT_PROPERTIES,
             Quantity::Temperature,
-            VifScaling::Auto,
+            VifScaling::AutoSigned,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ExternalTemperature)
@@ -99,7 +99,7 @@ namespace
              "The average temperature over the last 24 hours.",
              DEFAULT_PRINT_PROPERTIES,
             Quantity::Temperature,
-            VifScaling::Auto,
+            VifScaling::AutoSigned,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ExternalTemperature)
@@ -126,3 +126,7 @@ namespace
 // telegram=|2e44333003020100071b7a634820252f2f0265840842658308820165950802fb1aae0142fb1aae018201fb1aa9012f|
 // {"media":"room sensor","meter":"lansenth","name":"Tempoo","id":"00010203","status":"PERMANENT_ERROR SABOTAGE_ENCLOSURE","current_temperature_c":21.8,"current_relative_humidity_rh":43,"average_temperature_1h_c":21.79,"average_relative_humidity_1h_rh":43,"average_temperature_24h_c":21.97,"average_relative_humidity_24h_rh":42.5,"timestamp":"1111-11-11T11:11:11Z"}
 // |Tempoo;00010203;21.8;43;1111-11-11 11:11.11
+
+// Test: T2 lansenth 00060041 <KEY-REDACTED>
+// telegram=|2E44333041000600091B7AA70020252F2F_0265DBF94265FC04820165610901FB1B2C41FB1B238101FB1B290223BB00|+0
+// {"media":"room sensor","meter":"lansenth","name":"T2","id":"00060041","status":"OK","current_temperature_c":-15.73,"current_relative_humidity_rh":44,"average_temperature_1h_c":12.76,"average_relative_humidity_1h_rh":35,"average_temperature_24h_c":24.01,"average_relative_humidity_24h_rh":41,"timestamp":"2023-05-23T07:28:44Z"}

--- a/src/driver_lansenth.cc
+++ b/src/driver_lansenth.cc
@@ -53,7 +53,7 @@ namespace
              "The current temperature.",
              DEFAULT_PRINT_PROPERTIES,
             Quantity::Temperature,
-            VifScaling::Auto,
+            VifScaling::AutoSigned,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ExternalTemperature)


### PR DESCRIPTION
As discussed in #965 .
For me it's working fine over here.