### PR TITLE
[Topas ES KR] Handle negative values for flow

### DIFF
--- a/src/driver_topaseskr.cc
+++ b/src/driver_topaseskr.cc
@@ -77,7 +77,7 @@ namespace
             "The current water flow.",
             DEFAULT_PRINT_PROPERTIES,
             Quantity::Flow,
-            VifScaling::Auto,
+            VifScaling::AutoSigned,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::VolumeFlow));


### PR DESCRIPTION
I've seen negative values for smaller corrections. Currently they're showing up as unsigned (huge) values, which are obviously wrong. Similar to https://github.com/wmbusmeters/wmbusmeters/pull/966