### PR TITLE
Stop installation script on error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,19 +44,22 @@ do
         esac
 done
 
-SRC=$SRC ROOT=$ROOT /bin/sh ./scripts/install_binaries.sh
+SRC=$SRC ROOT=$ROOT /bin/sh ./scripts/install_binaries.sh || exit $?
 
-ROOT=$ROOT /bin/sh ./scripts/install_manpage.sh
+ROOT=$ROOT /bin/sh ./scripts/install_manpage.sh || exit $?
 
 if [ "$ADDUSER" = "true" ]
 then
-    ROOT=$ROOT /bin/sh ./scripts/add_wmbusmeters_user.sh
+    ROOT=$ROOT /bin/sh ./scripts/add_wmbusmeters_user.sh || exit $?
 fi
 
-ROOT=$ROOT /bin/sh ./scripts/prepare_logfiles.sh
+ROOT=$ROOT /bin/sh ./scripts/prepare_logfiles.sh || exit $?
 
-ROOT=$ROOT /bin/sh ./scripts/install_default_configuration.sh
+ROOT=$ROOT /bin/sh ./scripts/install_default_configuration.sh || exit $?
 
-ROOT=$ROOT /bin/sh ./scripts/install_systemd_service.sh
+ROOT=$ROOT /bin/sh ./scripts/install_systemd_service.sh || exit $?
 
-ROOT=$ROOT /bin/sh ./scripts/add_myself_to_dialout.sh
+ROOT=$ROOT /bin/sh ./scripts/add_myself_to_dialout.sh || exit $?
+
+echo
+echo "wmbusmetters sucessfully installed."

--- a/scripts/install_binaries.sh
+++ b/scripts/install_binaries.sh
@@ -1,10 +1,17 @@
 # Copyright (C) 2021-2023 Fredrik Öhrström (gpl-3.0-or-later)
 
-rm -f "$ROOT"/usr/bin/wmbusmeters "$ROOT"/usr/sbin/wmbusmetersd
-mkdir -p "$ROOT"/usr/bin
-mkdir -p "$ROOT"/usr/sbin
-cp "$SRC" "$ROOT"/usr/bin/wmbusmeters
+wmbusmeters_dir="$ROOT"/usr/bin
+wmbusmeters_path="$wmbusmeters_dir"/wmbusmeters
+wmbusmetersd_dir="$ROOT"/usr/sbin
+wmbusmetersd_path="$wmbusmetersd_dir"/wmbusmetersd
+wmbusmetersd_target=$(realpath -s --relative-to="$wmbusmetersd_dir" "$wmbusmeters_path")
 
-(cd "$ROOT"/usr/sbin; ln -s ../bin/wmbusmeters wmbusmetersd)
+rm -f "$wmbusmeters_path" "$wmbusmetersd_path" || exit $?⏎
 
-echo "binaries: installed $ROOT/usr/bin/wmbusmeters $ROOT/usr/sbin/wmbusmetersd"
+install -D -m 755 "$SRC" "$wmbusmeters_path" || exit $?⏎
+
+mkdir -p "$wmbusmetersd_dir" || exit $?
+
+ln -s "$wmbusmetersd_target" "$wmbusmetersd_path" || exit $?
+
+echo "binaries: installed '$wmbusmeters_path' '$wmbusmetersd_path'"


### PR DESCRIPTION
Just a little improvement to installation script
* replace `cp` by `install` with mode `755` in `install_binaries.sh`, so make sure that everyone is able to execute the `wmbusmeters`
* stop `./scripts/install_binaries.sh` on failure
* stop `./install.sh` on failure