### PR TITLE
Update driver_iwmtx5.cc

### DIFF
--- a/src/driver_iwmtx5.cc
+++ b/src/driver_iwmtx5.cc
@@ -32,6 +32,7 @@ namespace
         di.setMeterType(MeterType::HeatMeter);
         di.addLinkMode(LinkMode::T1);
         di.addDetection(MANUFACTURER_BMT, 0x07, 0x18);
+        di.addDetection(MANUFACTURER_BMT, 0x06, 0x18);
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
     });
 


### PR DESCRIPTION
Update driver iwmtx5

Received telegram from: 23329344
          manufacturer: (BMT) BMETERS, Italy (0x9b4)
                  type: Warm Water (30°C-90°C) meter (0x06)
                   ver: 0x18
                device: im871a[78563412]
                  rssi: -55 dBm
                driver: unknown!
telegram=|_4244B4094493322318068C005B7A1C0000000C13072000000F05170000000000000000000000000000000000000000009D0000C20000C20000C8000000000000000000|+39
