### PR TITLE
Update driver_kamheat.cc

### DIFF
--- a/src/driver_kamheat.cc
+++ b/src/driver_kamheat.cc
@@ -43,6 +43,7 @@ namespace
         di.addDetection(MANUFACTURER_KAM, 0x0c,  0x30); // 302
         di.addDetection(MANUFACTURER_KAM, 0x04,  0x40); // 303
         di.addDetection(MANUFACTURER_KAM, 0x0c,  0x40); // 303
+        di.addDetection(MANUFACTURER_KAM, 0x04,  0x19); // 402
         di.addDetection(MANUFACTURER_KAM, 0x04,  0x34); // 403
         di.addDetection(MANUFACTURER_KAM, 0x0a,  0x34); // 403
         di.addDetection(MANUFACTURER_KAM, 0x0b,  0x34); // 403


### PR DESCRIPTION
I would like to add support to Kamstrup Multical 402  heat meter. 
[simulate_KAM402.txt](https://github.com/wmbusmeters/wmbusmeters/files/13462723/simulate_KAM402.txt)
![Kam402](https://github.com/wmbusmeters/wmbusmeters/assets/149330119/5e00403c-88d2-4962-b228-3054bbeaa8da)
Adding Kamstrup Multical 402 Heat Meter