### PR TITLE
fix: date format should use semicolon as time separator

### DIFF
--- a/src/meters.cc
+++ b/src/meters.cc
@@ -738,7 +738,7 @@ string MeterCommonImplementation::datetimeOfUpdateHumanReadable()
 {
     char datetime[40];
     memset(datetime, 0, sizeof(datetime));
-    strftime(datetime, 20, "%Y-%m-%d %H:%M.%S", localtime(&datetime_of_update_));
+    strftime(datetime, 20, "%Y-%m-%d %H:%M:%S", localtime(&datetime_of_update_));
     return string(datetime);
 }
 


### PR DESCRIPTION
Small bug fix to replace a `.` with a `:` in the time component when printing a telegram in the human readable format