### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,18 @@
-FROM multiarch/alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable AS build
+FROM asymworks/multiarch-alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable AS build
 RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cmake libusb-dev bash
 RUN git clone https://github.com/wmbusmeters/wmbusmeters.git && \
-    git clone https://github.com/weetmuts/rtl-wmbus.git && \
-    git clone https://github.com/merbanan/rtl_433.git
+    git clone https://github.com/weetmuts/rtl-wmbus.git
 WORKDIR /wmbusmeters
 RUN make
 WORKDIR /rtl-wmbus
 RUN make release && chmod 755 build/rtl_wmbus
-WORKDIR /rtl_433
-RUN mkdir build && cd build && cmake ../ && make
 
-FROM multiarch/alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable as scratch
+FROM asymworks/multiarch-alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable as scratch
 ENV QEMU_EXECVE=1
-RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd
+RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd rtl_433
 WORKDIR /wmbusmeters
 COPY --from=build /wmbusmeters/build/wmbusmeters /wmbusmeters/wmbusmeters
 COPY --from=build /rtl-wmbus/build/rtl_wmbus /usr/bin/rtl_wmbus
-COPY --from=build /rtl_433/build/src/rtl_433 /usr/bin/rtl_433
 COPY --from=build /wmbusmeters/docker/docker-entrypoint.sh /wmbusmeters/docker-entrypoint.sh
 VOLUME /wmbusmeters_data/
 CMD ["sh", "/wmbusmeters/docker-entrypoint.sh"]


### PR DESCRIPTION
Changing alpine repo where latest version is available. 
With latest alpine version also latest rtl-sdr is available (0.8.0-r0) and rtl_433 is available as package, so no need to build it from source. 
Tested raspi 32 and 64bit with rtl-sdr, HA tests was not done.