### PR TITLE
added missing closing bracket

### DIFF
--- a/scripts/prepare_logfiles.sh
+++ b/scripts/prepare_logfiles.sh
@@ -44,6 +44,7 @@ then
     postrotate
         /bin/kill -HUP \`cat /run/wmbusmeters/wmbusmeters.pid 2> /dev/null\` 2> /dev/null || true
     endscript
+}
 EOF
     echo "logrotate: created $ROOT/etc/logrotate.d/wmbusmeters"
 else


### PR DESCRIPTION
I've noticed that the installed logrotate's configuration file for wmbusmeters is missing the closing curly bracket at the end.
I'm just proposing this teeny tiny fix. :-)