### PR TITLE
Update docker image, add rtl_reset

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -8,10 +8,28 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+'
       - '[0-9]+\.[0-9]+\.[0-9]+-RC[0-9]+'
 
+env:
+  DOCKERHUB_IMAGE: ${{ github.repository }}
+  IMAGE_TAG: |
+    ${{ github.ref_type == 'tag' && (contains(github.ref_name, '-RC') &&
+      join('candidate-', github.ref_name) || join('release-', github.ref_name)) || 'latest' }}
+
 jobs:
-  docker:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v7
+          - linux/arm64
     steps:
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -20,11 +38,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: wmbusmeters/wmbusmeters
-          tags: type=ref,event=tag
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          tags: |
+            ${{ env.IMAGE_TAG }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -35,29 +52,67 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PAT }}
       -
-        name: Build and push not tagged release
-        if: ${{ !steps.meta.outputs.tags }}
+        name: Build and push
         uses: docker/build-push-action@v5
+        id: docker_build
         with:
           context: docker/
-          platforms: linux/amd64,linux/arm64,linux/armhf
-          push: true
-          tags: wmbusmeters/wmbusmeters:latest
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          outputs: |
+            type=image,name=${{ env.DOCKERHUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       -
-        name: Build and push candidate
-        if: ${{ steps.meta.outputs.tags && contains(steps.meta.outputs.tags, '-RC') }}
-        uses: docker/build-push-action@v5
-        with:
-          context: docker/
-          platforms: linux/amd64,linux/arm64,linux/armhf
-          push: true
-          tags: wmbusmeters/wmbusmeters:candidate-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.docker_build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
       -
-        name: Build and push tagged release
-        if: ${{ steps.meta.outputs.tags && !contains(steps.meta.outputs.tags, '-RC') }}
-        uses: docker/build-push-action@v5
+        name: Upload digest
+        uses: actions/upload-artifact@v4
         with:
-          context: docker/
-          platforms: linux/amd64,linux/arm64,linux/armhf
-          push: true
-          tags: wmbusmeters/wmbusmeters:release-${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            ${{ env.IMAGE_TAG }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cm
 RUN git clone https://github.com/steve-m/librtlsdr.git && \
     git clone https://github.com/wmbusmeters/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
-    git clone https://github.com/merbanan/rtl_433.git
+    git clone https://github.com/merbanan/rtl_433.git && \
+    git clone https://github.com/ED6E0F17/rtl_reset.git
 WORKDIR /librtlsdr
 RUN cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=MinSizeRel \
@@ -20,6 +21,8 @@ WORKDIR /rtl_433
 RUN cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=MinSizeRel && \
     cmake --build build
+WORKDIR /rtl_reset
+RUN make
 
 FROM alpine as scratch
 RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd
@@ -30,6 +33,7 @@ COPY --from=build /librtlsdr/build/src/rtl_* /usr/bin/
 COPY --from=build /wmbusmeters/build/wmbusmeters /wmbusmeters/wmbusmeters
 COPY --from=build /rtl-wmbus/build/rtl_wmbus /usr/bin/rtl_wmbus
 COPY --from=build /rtl_433/build/src/rtl_433 /usr/bin/rtl_433
+COPY --from=build /rtl_reset/rtl_reset /usr/bin/rtl_reset
 COPY --from=build /wmbusmeters/docker/docker-entrypoint.sh /wmbusmeters/docker-entrypoint.sh
 VOLUME /wmbusmeters_data/
 CMD ["sh", "/wmbusmeters/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,17 @@
 FROM alpine AS build
 RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cmake libusb-dev bash samurai
-RUN git clone https://github.com/wmbusmeters/wmbusmeters.git && \
+RUN git clone https://github.com/steve-m/librtlsdr.git && \
+    git clone https://github.com/wmbusmeters/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
     git clone https://github.com/merbanan/rtl_433.git
+WORKDIR /librtlsdr
+RUN cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DDETACH_KERNEL_DRIVER=ON \
+        -Wno-dev && \
+    cmake --build build && \
+    cmake --install build
 WORKDIR /wmbusmeters
 RUN make
 WORKDIR /rtl-wmbus
@@ -15,6 +24,9 @@ RUN cmake -B build -G Ninja \
 FROM alpine as scratch
 RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd
 WORKDIR /wmbusmeters
+COPY --from=build /librtlsdr/build/src/librtlsdr.so.* /usr/lib/
+COPY --from=build /librtlsdr/rtl-sdr.rules /usr/lib/udev/rules.d/rtl-sdr.rules
+COPY --from=build /librtlsdr/build/src/rtl_* /usr/bin/
 COPY --from=build /wmbusmeters/build/wmbusmeters /wmbusmeters/wmbusmeters
 COPY --from=build /rtl-wmbus/build/rtl_wmbus /usr/bin/rtl_wmbus
 COPY --from=build /rtl_433/build/src/rtl_433 /usr/bin/rtl_433

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM asymworks/multiarch-alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable AS build
-RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cmake libusb-dev bash
+FROM alpine AS build
+RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cmake libusb-dev bash samurai
 RUN git clone https://github.com/wmbusmeters/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
     git clone https://github.com/merbanan/rtl_433.git
@@ -8,10 +8,11 @@ RUN make
 WORKDIR /rtl-wmbus
 RUN make release && chmod 755 build/rtl_wmbus
 WORKDIR /rtl_433
-RUN mkdir build && cd build && cmake ../ && make
+RUN cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=MinSizeRel && \
+    cmake --build build
 
-FROM asymworks/multiarch-alpine:${TARGETARCH}${TARGETVARIANT}-latest-stable as scratch
-ENV QEMU_EXECVE=1
+FROM alpine as scratch
 RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd
 WORKDIR /wmbusmeters
 COPY --from=build /wmbusmeters/build/wmbusmeters /wmbusmeters/wmbusmeters


### PR DESCRIPTION
Use latest alpine docker image with latest rtl_433 alpine package version.
Add rtl_reset to docker image.

Continuation: https://github.com/wmbusmeters/wmbusmeters/pull/991

For now, the only solution that works in my case is this code:
```rtl433:CMD(rtl_433 -R 104 -Y squelch -F csv -f 868.95M -s 1.6m; exit_code=$?; if [ $exit_code -ge 3 ]; then echo "`date '+%F %T %Z'` Reset rtl-sdr dongle (exit code: $exit_code)" >> /wmbusmeters_data/logs/wmbusmeters.log && rtl_reset && false; fi)```

`rtlsdr` even with this [change](https://github.com/steve-m/librtlsdr/commit/142325a93c6ad70f851f43434acfdf75e12dfe03) is not working properly.

Before merge you can check docker images from this repo: https://github.com/testuser7/wmbusmeters/pkgs/container/wmbusmeters/174628366?tag=dev (arm and arm64 architectures are not tested)