### PR TITLE
Do not install librtlsdr-dev and rtl-sdr packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS build
-RUN apk add --no-cache alpine-sdk gcc linux-headers librtlsdr-dev libxml2-dev cmake libusb-dev bash samurai
+RUN apk add --no-cache alpine-sdk gcc linux-headers libxml2-dev cmake libusb-dev bash samurai
 RUN git clone https://github.com/steve-m/librtlsdr.git && \
     git clone https://github.com/wmbusmeters/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
@@ -25,7 +25,7 @@ WORKDIR /rtl_reset
 RUN make
 
 FROM alpine as scratch
-RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb rtl-sdr libxml2 netcat-openbsd
+RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb libxml2 netcat-openbsd
 WORKDIR /wmbusmeters
 COPY --from=build /librtlsdr/build/src/librtlsdr.so.* /usr/lib/
 COPY --from=build /librtlsdr/rtl-sdr.rules /usr/lib/udev/rules.d/rtl-sdr.rules


### PR DESCRIPTION
There is no need to install them because we use the sources directly.

```
#11 2.237 -- Install configuration: "MinSizeRel"
#11 2.237 -- Installing: /usr/include/rtl-sdr.h
#11 2.237 -- Installing: /usr/include/rtl-sdr_export.h
#11 2.238 -- Installing: /usr/lib/pkgconfig/librtlsdr.pc
#11 2.238 -- Installing: /usr/lib/cmake/rtlsdr/rtlsdrTargets.cmake
#11 2.239 -- Installing: /usr/lib/cmake/rtlsdr/rtlsdrTargets-minsizerel.cmake
#11 2.239 -- Installing: /usr/lib/cmake/rtlsdr/rtlsdrConfig.cmake
#11 2.239 -- Installing: /usr/lib/cmake/rtlsdr/rtlsdrConfigVersion.cmake
#11 2.240 -- Installing: /usr/lib/librtlsdr.so.2.0.1
#11 2.241 -- Installing: /usr/lib/librtlsdr.so.2
#11 2.241 -- Installing: /usr/lib/librtlsdr.so
#11 2.241 -- Installing: /usr/lib/librtlsdr.a
#11 2.242 -- Installing: /usr/bin/rtl_sdr
#11 2.243 -- Set runtime path of "/usr/bin/rtl_sdr" to ""
#11 2.243 -- Installing: /usr/bin/rtl_tcp
#11 2.244 -- Set runtime path of "/usr/bin/rtl_tcp" to ""
#11 2.244 -- Installing: /usr/bin/rtl_test
#11 2.244 -- Set runtime path of "/usr/bin/rtl_test" to ""
#11 2.245 -- Installing: /usr/bin/rtl_fm
#11 2.245 -- Set runtime path of "/usr/bin/rtl_fm" to ""
#11 2.246 -- Installing: /usr/bin/rtl_eeprom
#11 2.246 -- Set runtime path of "/usr/bin/rtl_eeprom" to ""
#11 2.246 -- Installing: /usr/bin/rtl_adsb
#11 2.247 -- Set runtime path of "/usr/bin/rtl_adsb" to ""
#11 2.247 -- Installing: /usr/bin/rtl_power
#11 2.248 -- Set runtime path of "/usr/bin/rtl_power" to ""
#11 2.248 -- Installing: /usr/bin/rtl_biast
#11 2.249 -- Set runtime path of "/usr/bin/rtl_biast" to ""
#11 DONE 2.3s
```