### PR TITLE
Adding a better description of combinable extension vife

### DIFF
--- a/src/dvparser.cc
+++ b/src/dvparser.cc
@@ -448,7 +448,7 @@ bool parseDV(Telegram *t,
                     if (data_has_difvifs)
                     {
                         t->addExplanationAndIncrementPos(*format, 1, KindOfData::PROTOCOL, Understanding::FULL,
-                                                         "%02X combinable extension vife", vife);
+                                                         "%02X combinable extension vife (%s)", vife, toString(vc));
                     }
                 }
                 else


### PR DESCRIPTION
Currently there is no description of what combinable vife is read from frame is it's an extension.
So I add this small feature...