### PR TITLE
Avoid SIGSEGV in WMBusCUL::checkCULFrame

### DIFF
--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -331,6 +331,7 @@ FrameStatus WMBusCUL::checkCULFrame(vector<uchar> &data,
         string s = safeString(hex_buffer);
         debug("(cul) bad hex for LQI and RSSI \"%s\"\n", s.c_str());
         warning("(cul) warning: the LQI and RSSI hex string is not properly formatted!\n");
+	return ErrorInFrame;
     }
     // LQI is 7 bits unsigned number and relative - range 0-127 lower is better
     uint lqi = lqi_rssi[0]>>1;


### PR DESCRIPTION

```
(cul) checkCULFrame "b2F4468506586269295620A17A2069F2" (cul) no eol found yet, partial frame
(serial) received ascii "TMODE<0D><0A>b2F44685086625092957245C6A2069F2F6A06E0080000000000000000B9BF00000D0F0D11130512100F0F0F100F0F8E1F0F0E0D121310B241<0D><0A>b4E44B61065960200023732117A0E004005E4B5FD2A1E3DCCC84F38BDF21FD05D506BF685D50CB3AD9644F9FF7C893BF9DD0D2B64C85F703707B1965C69261E8CDF85046CDDC38F1336D67750E933854BA0C9A91240A18556E6064B<0D><0A>" (cul) checkCULFrame "b2F4468506586269295620A17A2069F2TMODE<0D><0A>b2F44685086625092957245C6A2069F2F6A06E0080000000000000000B9BF00000D0F0D11130512100F0F0F100F0F8E1F0F0E0D121310B241<0D><0A>b4E44B61065960200023732117A0E004005E4B5FD2A1E3DCCC84F38BDF21FD05D506BF685D50CB3AD9644F9FF7C893BF9DD0D2B64C85F703707B1965C69261E8CDF85046CDDC38F1336D67750E933854BA0C9A91240A18556E6064B<0D><0A>" (cul) bad hex for LQI and RSSI "MODE"
(cul) warning: the LQI and RSSI hex string is not properly formatted!

Thread 2 "wmbusmeters" received signal SIGSEGV, Segmentation fault. 0x571c718f in WMBusCUL::checkCULFrame (this=0xf0a03480, data=std::vector of length 339, capacity 339 = {...}, hex_frame_length=0xf07fe680,
    payload=std::vector of length 0, capacity 0, rssi_dbm=0xf07fe6c0) at src/wmbus_cul.cc:336
336         uint lqi = lqi_rssi[0]>>1;
(gdb)
``` 
