### PR TITLE
Update driver_izar.cc - Fix the serial number construction for 200x years

### DIFF
--- a/src/driver_izar.cc
+++ b/src/driver_izar.cc
@@ -211,6 +211,7 @@ namespace
         if (detectDiehlFrameInterpretation(frame) == DiehlFrameInterpretation::SAP_PRIOS)
         {
             string digits = to_string((origin[7] & 0x03) << 24 | origin[6] << 16 | origin[5] << 8 | origin[4]);
+            digits = tostrprintf("%08d", atoi(digits.c_str())); // Make sure we are on 8 digits for 200x years
             // get the manufacture year
             uint8_t yy = atoi(digits.substr(0, 2).c_str());
             int manufacture_year = yy > 70 ? (1900 + yy) : (2000 + yy); // Maybe to adjust in 2070, if this code stills lives :D


### PR DESCRIPTION
Fix the serial number construction for 200x years

I have a meter from 2009 that is wrongly analysed as 1990
The manufacture year is taken from the first two digit. 
But for the year 200X, the leading '0' is missing. hence the error

Before fix:
```shell
$ ./wmbusmeters --analyze 1344304cf3628920Bc01a0712f03130ceB627a81
Auto driver  : izar
Best driver  : unknown 00/00
Using driver : izar 00/00
000   : 13 length (19 bytes)
001   : 44 dll-c (from meter SND_NR)
002   : 304c dll-mfct (SAP)
004   : f3628920 dll-id (208962f3)
008   : 00 dll-version
009   : 07 dll-type (Water meter)
010   : a0 tpl-ci-field (Mfct specific)
011 C?: 712F03130CEB627A81 mfct specific

{
    "media":"water",
    "meter":"izar",
    "name":"",
    "id":"208962f3",
    "last_month_total_m3":3758096.511,
    "remaining_battery_life_y":7.5,
    "total_m3":1248.146,
    "transmit_period_s":8,
    "current_alarms":"meter_blocked,mechanical_fraud",
    "last_month_measure_date":"2065-12-28",
    "manufacture_year":"1990",
    "prefix":"C90OA",
    "previous_alarms":"mechanical_fraud",
    "serial_number":"003763",
    "timestamp":"2024-06-12T07:43:35Z"
}
``` 

after fix:
```shell
$ ./wmbusmeters --analyze 1344304cf3628920Bc01a0712f03130ceB627a81
Auto driver  : izar
Best driver  : unknown 00/00
Using driver : izar 00/00
000   : 13 length (19 bytes)
001   : 44 dll-c (from meter SND_NR)
002   : 304c dll-mfct (SAP)
004   : f3628920 dll-id (208962f3)
008   : 00 dll-version
009   : 07 dll-type (Water meter)
010   : a0 tpl-ci-field (Mfct specific)
011 C?: 712F03130CEB627A81 mfct specific

{
    "media":"water",
    "meter":"izar",
    "name":"",
    "id":"208962f3",
    "last_month_total_m3":3758096.511,
    "remaining_battery_life_y":7.5,
    "total_m3":1248.146,
    "transmit_period_s":8,
    "current_alarms":"meter_blocked,mechanical_fraud",
    "last_month_measure_date":"2014-03-12",
    "manufacture_year":"2009",
    "prefix":"C09OA",
    "previous_alarms":"mechanical_fraud",
    "serial_number":"003763",
    "timestamp":"2024-06-12T09:04:48Z"
}
``` 