### PR TITLE
Update the BMeters hydrodigit driver

### DIFF
--- a/src/driver_hydrodigit.cc
+++ b/src/driver_hydrodigit.cc
@@ -13,55 +13,287 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #include"meters_common_implementation.h"
 
-namespace
-{
-    struct Driver : public virtual MeterCommonImplementation
-    {
-        Driver(MeterInfo &mi, DriverInfo &di);
-    };
+namespace {
+	struct Driver: public virtual MeterCommonImplementation {
+			Driver(MeterInfo &mi, DriverInfo &di);
+			void processContent(Telegram *t);
+	};
 
-    static bool ok = registerDriver([](DriverInfo&di)
-    {
-        di.setName("hydrodigit");
-        di.setDefaultFields("name,id,total_m3,meter_datetime,timestamp");
-        di.setMeterType(MeterType::WaterMeter);
-        di.addLinkMode(LinkMode::T1);
-        di.addDetection(MANUFACTURER_BMT,  0x06,  0x13);
-        di.addDetection(MANUFACTURER_BMT,  0x06,  0x17);
-        di.addDetection(MANUFACTURER_BMT,  0x07,  0x13);
-        di.addDetection(MANUFACTURER_BMT,  0x07,  0x15);
-        di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
-    });
+	static bool ok = registerDriver([](DriverInfo &di) {
+		di.setName("hydrodigit");
+		di.setDefaultFields("name,id,total_m3,meter_datetime,timestamp");
+		di.setMeterType(MeterType::WaterMeter);
+		di.addLinkMode(LinkMode::T1);
+		di.addDetection(MANUFACTURER_BMT, 0x06, 0x13);
+		di.addDetection(MANUFACTURER_BMT, 0x06, 0x17);
+		di.addDetection(MANUFACTURER_BMT, 0x07, 0x13);
+		di.addDetection(MANUFACTURER_BMT, 0x07, 0x15);
+		di.usesProcessContent();
+		di.setConstructor([](MeterInfo &mi, DriverInfo &di) {
+			return shared_ptr<Meter>(new Driver(mi, di));
+		});
+	});
 
-    Driver::Driver(MeterInfo &mi, DriverInfo &di) : MeterCommonImplementation(mi, di)
-    {
-        addNumericFieldWithExtractor(
-            "total",
-            "The total water consumption recorded by this meter.",
-            DEFAULT_PRINT_PROPERTIES,
-            Quantity::Volume,
-            VifScaling::Auto, DifSignedness::Signed,
-            FieldMatcher::build()
-            .set(MeasurementType::Instantaneous)
-            .set(VIFRange::Volume)
-            );
+	Driver::Driver(MeterInfo &mi, DriverInfo &di) : MeterCommonImplementation(
+			mi, di) {
+		addNumericFieldWithExtractor("total",
+				"The total water consumption recorded by this meter.",
+				DEFAULT_PRINT_PROPERTIES, Quantity::Volume, VifScaling::Auto,
+				DifSignedness::Signed,
+				FieldMatcher::build().set(MeasurementType::Instantaneous).set(
+						VIFRange::Volume));
 
-        addNumericFieldWithExtractor(
-            "meter",
-            "Meter timestamp for measurement.",
-            DEFAULT_PRINT_PROPERTIES,
-            Quantity::PointInTime,
-            VifScaling::Auto, DifSignedness::Signed,
-            FieldMatcher::build()
-            .set(MeasurementType::Instantaneous)
-            .set(VIFRange::DateTime),
-            Unit::DateTimeLT
-            );
-    }
+		addNumericFieldWithExtractor("meter",
+				"Meter timestamp for measurement.",
+				DEFAULT_PRINT_PROPERTIES, Quantity::PointInTime,
+				VifScaling::Auto, DifSignedness::Signed,
+				FieldMatcher::build().set(MeasurementType::Instantaneous).set(
+						VIFRange::DateTime), Unit::DateTimeLT);
+		addStringField("contents", "Contents of this telegrams",
+				DEFAULT_PRINT_PROPERTIES);
+		addNumericField("voltage", Quantity::Voltage, DEFAULT_PRINT_PROPERTIES,
+				"Voltage of the battery inside the meter", Unit::Volt);
+		addStringField("leak_date", "Date of leakage detected by meter",
+				DEFAULT_PRINT_PROPERTIES);
+		addNumericField("backflow", Quantity::Volume, DEFAULT_PRINT_PROPERTIES,
+				"Backflow detected by the meter", Unit::M3);
+		addNumericField("January_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of January",
+				Unit::M3);
+		addNumericField("February_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of February",
+				Unit::M3);
+		addNumericField("March_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of March",
+				Unit::M3);
+		addNumericField("April_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of April",
+				Unit::M3);
+		addNumericField("May_total", Quantity::Volume, DEFAULT_PRINT_PROPERTIES,
+				"Total value at the end of May", Unit::M3);
+		addNumericField("June_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of June",
+				Unit::M3);
+		addNumericField("July_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of July",
+				Unit::M3);
+		addNumericField("August_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of August",
+				Unit::M3);
+		addNumericField("September_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of September",
+				Unit::M3);
+		addNumericField("October_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of October",
+				Unit::M3);
+		addNumericField("November_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of November",
+				Unit::M3);
+		addNumericField("December_total", Quantity::Volume,
+				DEFAULT_PRINT_PROPERTIES, "Total value at the end of December",
+				Unit::M3);
+
+	}
+
+	double fromMonthly(uchar first_byte, uchar second_byte, uchar third_byte) {
+		return ((double) (third_byte << 16 | second_byte << 8 | first_byte))
+				/ 100.0;
+	}
+
+	double fromBackflow(uchar first_byte, uchar second_byte, uchar third_byte,
+			uchar fourth_byte) {
+		return ((double) (fourth_byte << 24 | third_byte << 16
+				| second_byte << 8 | first_byte)) / 1000.0;
+	}
+
+	string getMonth(int month) {
+		switch (month) {
+			case 1:
+				return "January";
+			case 2:
+				return "February";
+			case 3:
+				return "March";
+			case 4:
+				return "April";
+			case 5:
+				return "May";
+			case 6:
+				return "June";
+			case 7:
+				return "July";
+			case 8:
+				return "August";
+			case 9:
+				return "September";
+			case 10:
+				return "October";
+			case 11:
+				return "November";
+			case 12:
+				return "December";
+			default:
+				return "Month out of range :)";
+		}
+	}
+
+	double getVoltage(uchar voltage_byte) {
+		uchar relevant_half = voltage_byte & 0x0F; // ensure dumping of top half
+		switch (relevant_half) {
+			case 0x01:
+				return 1.9;
+			case 0x02:
+				return 2.1;
+			case 0x03:
+				return 2.2;
+			case 0x04:
+				return 2.3;
+			case 0x05:
+				return 2.4;
+			case 0x06:
+				return 2.5;
+			case 0x07:
+				return 2.65;
+			case 0x08:
+				return 2.8;
+			case 0x09:
+				return 2.9;
+			case 0x0A:
+				return 3.05;
+			case 0x0B:
+				return 3.2;
+			case 0x0C:
+				return 3.35;
+			case 0x0D:
+				return 3.5;
+			default:
+				return 3.7; // 0, E and F all are 3.7
+		}
+
+	}
+
+	void Driver::processContent(Telegram *t) {
+		if (t->mfct_0f_index == -1) return; // Check that there is mfct data.
+		int offset = t->header_size + t->mfct_0f_index;
+
+		vector<uchar> bytes;
+		t->extractMfctData(&bytes); // Extract raw frame data after the DIF 0x0F.
+
+		debugPayload("(hydrodigit mfct)", bytes);
+
+		int i = 0;
+		int len = bytes.size();
+
+		if (i >= len) return;
+		uchar frame_identifier = bytes[i];
+		if (frame_identifier == 0x15) {
+			t->addSpecialExplanation(i + offset, 1, KindOfData::PROTOCOL,
+					Understanding::FULL, "*** %02X frame content: %s",
+					frame_identifier, "Backflow, alarms and monthly data");
+			setStringValue("contents", "Backflow, alarms and monthly data");
+		} else if (frame_identifier == 0x95) {
+			t->addSpecialExplanation(i + offset, 1, KindOfData::PROTOCOL,
+					Understanding::FULL, "*** %02X frame content: %s",
+					frame_identifier,
+					"Backflow, leak date, alarms and monthly data");
+			setStringValue("contents",
+					"Backflow, leak date, alarms and monthly data");
+		} else {
+			t->addSpecialExplanation(i + offset, 1, KindOfData::PROTOCOL,
+					Understanding::NONE,
+					"*** %02X frame content unknown, please open issue with this telegram for driver improvement",
+					frame_identifier);
+			setStringValue("contents",
+					"unknown, please open issue with this telegram for driver improvement");
+			return;
+		}
+		i++;
+
+
+		if (i >= len) return;
+		// only the bottom half changes the voltage, top half's purpose is unknown
+		// values obtained from software by changing value from 0x00-0F
+		// changing the top half didn't seem to change anything, but it might require a combination with other bytes
+		// my meters have 0x0A and 0x2A but the data seems same
+		uchar somethingAndVoltage = bytes[i];
+		double voltage = getVoltage(somethingAndVoltage & 0x0F);
+		t->addSpecialExplanation(i + offset, 1, KindOfData::CONTENT,
+				Understanding::FULL,
+				"*** %02X voltage of battery %0.2f V",
+				somethingAndVoltage, voltage);
+		setNumericValue("voltage", Unit::Volt, voltage);
+		i++;
+
+
+		if (frame_identifier == 0x95) {
+			if (i + 2 >= len) return;
+			uchar leak_year = bytes[i];
+			uchar leak_month = bytes[i + 1];
+			uchar leak_day = bytes[i + 2];
+			// its BCD so I just print it as is
+			t->addSpecialExplanation(i + offset, 3, KindOfData::CONTENT,
+					Understanding::FULL,
+					"*** %02X%02X%02X date of leakage: %02X.%02X.20%02X",
+					bytes[i],
+					bytes[i + 1], bytes[i + 2], leak_day, leak_month,
+					leak_year);
+			char buffer[16];
+			sprintf(buffer, "%02X.%02X.20%02X", leak_day, leak_month,
+					leak_year);
+			setStringValue("leak_date", buffer);
+
+			i += 3;
+		}
+
+
+		if (i + 3 >= len) return;
+		// backflow detected by the meter, has higher precision than normal values
+		double backflow = fromBackflow(bytes[i], bytes[i + 1], bytes[i + 2],
+				bytes[i + 3]);
+		t->addSpecialExplanation(i + offset, 4, KindOfData::CONTENT,
+				Understanding::FULL, "*** %02X%02X%02X%02X backflow: %0.3f m3",
+				bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3],
+				backflow);
+		setNumericValue("backflow", Unit::M3, backflow);
+		
+		i += 4;
+
+		double monthData;
+		string month_field_name;
+		for (int month = 1; month <= 12; ++month) {
+			if (i + 2 >= len) return;
+			month_field_name.clear();
+			month_field_name.append(getMonth(month)).append("_total");
+			monthData = fromMonthly(bytes[i], bytes[i + 1], bytes[i + 2]);
+			// one of our meters was installed backwards so we know the max value is 99999,99
+			// anything above (which should only be FFFFFF, more on that below) should be 0
+			// FFFFFF (167772,15) means module was not active back then (before installation) - translates to 0
+			if (monthData >= 100000) monthData = 0;
+			t->addSpecialExplanation(i + offset, 3, KindOfData::CONTENT,
+					Understanding::FULL,
+					"*** %02X%02X%02X total consumption at the end of %s: %0.2f m3",
+					bytes[i], bytes[i + 1], bytes[i + 2],
+					getMonth(month).c_str(),
+					monthData);
+			setNumericValue(month_field_name, Unit::M3, monthData);
+			i += 3;
+		}
+
+		if (i >= len) return;
+		// changing this byte didn't seem to do anything
+		// and it's always 00 on my meters
+		uchar unknown = bytes[i];
+		t->addSpecialExplanation(i + offset, 1, KindOfData::CONTENT,
+				Understanding::NONE,
+				"*** %02X unknown data",
+				unknown);
+		i++;
+		// there should not be any more data
+	}
 }
 
 // Test: HydrodigitWater hydrodigit 86868686 NOKEY


### PR DESCRIPTION
Update for the hydrodigit driver

## Bit of backstory
I've had access to BMetering software and their RFM-RX2 adapter for a few years now, but I've recently acquired the MBWUSB2 868, which comes with a lot of handy features, one of them being the ability to send (emulate) a meter response.

I've been able to decode most of the hydrodigit packet, by capturing the data from a real meter by the MBWUSB, storing them and then retransmitting those data outside of the range of the meter (to ensure the software gets the data we have and can analyze), and capturing those with the RFM and the software.

## Two of my packets
These packets were chosen intentionally, as they show how frame ids work, how a backflow is encoded, contain monthly data and the second one even has a water leak.

Before this change, the driver was able to understand only the `0C` and `04` DIFs (total_m3 and meter_datetime)

(module ids modified for the sake of privacy)
1. `4644B4092143658713077A9C000000 0C1364390400 046D212F1635 0F152A0F000000440F00C00F00511000D51000B20B00180C007C0C00E60C00560D00D10D00400E00C60E0000` - this is a nice one to showcase the backflow encoding
2. `4944B4092243658713077A7F000000 0C1363020400 046D242C1236 0F950A24042507000000A405006E0700850900CA0B004A0E00FFFFFFFFFFFF020000020000250000B3010095030000` - this one adds a leak date to the definition, plus shows how the monthly data looks before module installation

## The decoding
Sending it to the software, the first packet fills in 17 columns, the second one adds leak date. Two of these columns are from the `0C` and `04` DIFs and the rest is / must be in the 0F data.

In the following part, I will strip the bytes from the beginning and when the value has a corresponding value in the software, I will write it in the ( ) brackets at the end of the line.
&nbsp;

#### Dissecting the first packet's `0F` part:
`0F 152A0F000000440F00C00F00511000D51000B20B00180C007C0C00E60C00560D00D10D00400E00C60E0000`
`0F` - DIF - manufacturer specific data - obvious
&nbsp;

`15 2A0F000000440F00C00F00511000D51000B20B00180C007C0C00E60C00560D00D10D00400E00C60E0000`
`15` - defines the content of the data that follows, each bit might define a part of the message, or it could be just an index to a map of responses, naming it frame identifier similar to the hydroclima driver https://github.com/wmbusmeters/wmbusmeters/blob/901674d700f324b9faef80bc13680ae98b03c9a0/src/driver_hydroclima.cc#L119-L122 (has no equivalent in the software as it defines what the packet contains and which columns will be filled)
&nbsp;

`2A 0F000000440F00C00F00511000D51000B20B00180C007C0C00E60C00560D00D10D00400E00C60E0000`
`2A` - the purpose of the top half of the byte is unknown, the bottom half (`A` in this case) contains the voltage of the battery inside the module - the values are mapped as they don't increment at steady rate - `0`, `E` and `F` all map to 3.7 V, the rest from `1` to `D` is 1.9, 2.1, 2.2, 2.3, 2.4, 2.5, 2.65, 2.8, 2.9, 3.05, 3.2, 3.35, 3.5 (in software column named voltage = 3.05)
&nbsp;

`0F000000 440F00C00F00511000D51000B20B00180C007C0C00E60C00560D00D10D00400E00C60E0000`
`0F000000` - backflow - int32 - divide by 1000 to get the value in m3 (backflow shown as 0.015 m3)
&nbsp;

`440F00 C00F00 511000 D51000 B20B00 180C00 7C0C00 E60C00 560D00 D10D00 400E00 C60E00 00`
Next 12 x 3 bytes are the monthly values - be careful that they are ordered as months, as in January, February... and not (current month) -1, -2 etc.

The values represent the "total value" recorded at the end of the specified month (e.g. the value in the April column should be the same, as the value you could read as the "total_m3" at the midnight between April 30th and May 1st).

When reading from module before the "end of the month value" gets written, the value for that month is actually previous year's value, meaning the April value can be higher than the May value, when you're reading the meter in May.

`440F00` - int24 - January data - divide by 100 to get the value in m3 (39.08)
`C00F00` - int24 - February data - divide by 100 to get the value in m3 (40.32)
`511000` - int24 - March data - divide by 100 to get the value in m3 (41.77)
`D51000` - int24 - April data - divide by 100 to get the value in m3 (43.09)
`B20B00` - int24 - May data - divide by 100 to get the value in m3 (29.94)
`180C00` - int24 - June data - divide by 100 to get the value in m3 (30.96)
`7C0C00` - int24 - July data - divide by 100 to get the value in m3 (31.96)
`E60C00` - int24 - August data - divide by 100 to get the value in m3 (33.02)
`560D00` - int24 - September data - divide by 100 to get the value in m3 (34.14)
`D10D00` - int24 - October data - divide by 100 to get the value in m3 (35.37)
`400E00` - int24 - November data - divide by 100 to get the value in m3 (36.48)
`C60E00` - int24 - December data - divide by 100 to get the value in m3 (37.82)

and the remaining `00` with unknown purpose
&nbsp;

#### Few highlights from the second packet's `0F` part:
`0F 95 0A 240425 07000000 A40500 6E0700 850900 CA0B00 4A0E00 FFFFFF FFFFFF 020000 020000 250000 B30100 950300 00`
The frame identifier is `95` (only a single bit difference from `15`, and contains only one more info - might be a coincidence, might not) - adds leak date as the first 3 bytes after voltage and before backflow.

Speaking of voltage, the byte is now `0A` and it's still parsed only as voltage: 3.05 V

`240425` - leak date in YYMMDD format, all in BCD (in software: leak date: 25.04.2024)

Another obvious difference are the `FFFFFF` months, these are before the module was active and get translated to 0. The next two months have a small amount flowed through them during the product verification. 
&nbsp;

Anyone who can count might have noticed that the number of columns decoded from the packet is 16 (+1 for leak date in the second packet) - 2 from before the `0F`, 1 voltage, 1 backflow and 12 monthly data, but in the beginning, I said it fills 17 (+1). That last one is "number of alarms" field, which was always zero for the tested packets. I've tried changing the `00` with unknown purpose at the end to see if it was somehow encoded in there, but none of the tested hex values seemed to change anything. The number of alarms might also be derived from the frame identifier, which might specify that there will be an "errors" field in the packet and if it's not there, then just print 0. But that's all just a speculation on how it works.

## Conclusion
Enjoy the updated driver and if you have a packet with different frame identifier than the ones identified (if you try to run it through, it will tell you), please open an issue with the packet included so we can all learn more.

Before someone says it, I know there is a packet with a different frame id in the driver file (the warm water one), specifically frame id `03`, but it doesn't contain much (the first `00` after the frame id has an unknown purpose, the rest - 4x `00` is mapped to backflow). Didn't include that in the driver as I've never seen a packet like that elsewhere (plus it would be slightly annoying to add, as it has a different structure). There is one interesting thing about that packet - it doesn't have the `00` with unknown purpose at the end, which might suggest that it's somehow related to some part of the other data.
&nbsp;

Also, if anyone wants to add / improve the decoding on any BMeters products I might be able to help with that (the least I can do is translate the data to columns and values for you, so you could figure out how that's all in there)
