### PR TITLE
Driver detection for (DEV) Develco Products Electricity Meter Version 0x01

### DIFF
--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -33,6 +33,7 @@ namespace
         di.addDetection(MANUFACTURER_APA,  0x02,  0x02);
         di.addDetection(MANUFACTURER_DEV,  0x37,  0x02);
         di.addDetection(MANUFACTURER_DEV,  0x02,  0x00);
+        di.addDetection(MANUFACTURER_DEV,  0x02,  0x01);
         // Apator Otus 1/3 seems to use both, depending on a frame.
         // Frames with APA are successfully decoded by this driver
         // Frames with APT are not - and their content is unknown - perhaps it broadcasts two data formats?


### PR DESCRIPTION
The driver for the Develco Products Electricity Meter Version 0x01, as use by my local grid operator linznetz.at, is not detected automatically:

```
./build/wmbusmeters auto:t1
Started auto cul on /dev/ttyUSB0 listening on t1
No meters configured. Printing id:s of all telegrams heard!
Received telegram from: 00320787
          manufacturer: (DEV) Develco Products, Denmark (0x10b6)
                  type: Electricity meter (0x02) encrypted
                   ver: 0x01
                device: cul
                  rssi: -52 dBm
                driver: unknown!
```

It seems, however, that the amiplus driver works, as identified by `--analyze`:

```
./build/wmbusmeters --analyze=<key> auto:t1
Started auto cul on /dev/ttyUSB0 listening on t1
Auto driver    : not found!
Similar driver : amiplus 24/28
Using driver   : amiplus 24/28
000   : 3e length (62 bytes)
001   : 44 dll-c (from meter SND_NR)
002   : b610 dll-mfct (DEV)
004   : 87073200 dll-id (00320787)
008   : 01 dll-version
009   : 02 dll-type (Electricity meter)
010   : 7a tpl-ci-field (EN 13757-3 Application Layer (short tplh))
011   : 38 tpl-acc-field
012   : 00 tpl-sts-field (OK)
013   : 3005 tpl-cfg 0530 (AES_CBC_IV nb=3 cntn=0 ra=0 hc=0 )
015   : 2f2f decrypt check bytes (OK)
017   : 0C dif (8 digit BCD Instantaneous value)
018   : 78 vif (Fabrication no)
019 C?: 30253390
023   : 06 dif (48 Bit Integer/Binary Instantaneous value)
024   : 6D vif (Date and time type)
025 C!: 687214123940 ("device_date_time":"2024-09-18 20:50:40")
031   : 0E dif (12 digit BCD Instantaneous value)
032   : 03 vif (Energy Wh)
033 C!: 189169000000 ("total_energy_consumption_kwh":699.118)
039   : 0E dif (12 digit BCD Instantaneous value)
040   : 83 vif (Energy Wh)
041   : 3C combinable vif (BackwardFlow)
042 C!: 926501000000 ("total_energy_production_kwh":16.592)
048   : 0B dif (6 digit BCD Instantaneous value)
049   : 2B vif (Power W)
050 C!: 260200 ("current_power_consumption_kw":0.226)
053   : 0B dif (6 digit BCD Instantaneous value)
054   : AB vif (Power W)
055   : 3C combinable vif (BackwardFlow)
056 C!: 000000 ("current_power_production_kw":0)
059   : 2F skip
060   : 2F skip
061   : 2F skip
062   : 2F skip

{
    "media":"electricity",
    "meter":"amiplus",
    "name":"",
    "id":"00320787",
    "current_power_consumption_kw":0.226,
    "current_power_production_kw":0,
    "total_energy_consumption_kwh":699.118,
    "total_energy_production_kwh":16.592,
    "device_date_time":"2024-09-18 20:50:40",
    "timestamp":"2024-09-18T18:50:41Z",
    "device":"cul",
    "rssi_dbm":-53
}
```
It seems to match the message format as described by my operator here (German only): https://www.linznetz.at//media/linz_netz_website/netz_dokumente/Beschreibung-Wireless_M-Bus-Schnittstelle.pdf

Thus, adding detection for version 0x01 seems correct to me.