### PR TITLE
More generic voltage for amiplus.

### DIFF
--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -116,6 +116,36 @@ namespace
             .set(DifVifKey("0AFDC9FC03"))
             );
 
+        addNumericFieldWithExtractor(
+            "voltage_at_phase_1",
+            "Voltage at phase L1.",
+            DEFAULT_PRINT_PROPERTIES,
+            Quantity::Voltage,
+            VifScaling::None, DifSignedness::Signed,
+            FieldMatcher::build()
+            .set(DifVifKey("0AFDC8FC01"))
+            );
+
+        addNumericFieldWithExtractor(
+            "voltage_at_phase_2",
+            "Voltage at phase L2.",
+            DEFAULT_PRINT_PROPERTIES,
+            Quantity::Voltage,
+            VifScaling::None, DifSignedness::Signed,
+            FieldMatcher::build()
+            .set(DifVifKey("0AFDC8FC02"))
+            );
+
+        addNumericFieldWithExtractor(
+            "voltage_at_phase_3",
+            "Voltage at phase L3.",
+            DEFAULT_PRINT_PROPERTIES,
+            Quantity::Voltage,
+            VifScaling::None, DifSignedness::Signed,
+            FieldMatcher::build()
+            .set(DifVifKey("0AFDC8FC03"))
+            );
+
         addStringFieldWithExtractor(
             "device_date_time",
             "Device date time.",

--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -91,9 +91,11 @@ namespace
             "Voltage at phase L1.",
             DEFAULT_PRINT_PROPERTIES,
             Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
+            VifScaling::Auto, DifSignedness::Signed,
             FieldMatcher::build()
-            .set(DifVifKey("0AFDC9FC01"))
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Voltage)
+            .add(VIFCombinable::AtPhase1)
             );
 
         addNumericFieldWithExtractor(
@@ -101,9 +103,11 @@ namespace
             "Voltage at phase L2.",
             DEFAULT_PRINT_PROPERTIES,
             Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
+            VifScaling::Auto, DifSignedness::Signed,
             FieldMatcher::build()
-            .set(DifVifKey("0AFDC9FC02"))
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Voltage)
+            .add(VIFCombinable::AtPhase2)
             );
 
         addNumericFieldWithExtractor(
@@ -111,9 +115,11 @@ namespace
             "Voltage at phase L3.",
             DEFAULT_PRINT_PROPERTIES,
             Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
+            VifScaling::Auto, DifSignedness::Signed,
             FieldMatcher::build()
-            .set(DifVifKey("0AFDC9FC03"))
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Voltage)
+            .add(VIFCombinable::AtPhase3)
             );
 
         addNumericFieldWithExtractor(

--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2019-2022 Fredrik Öhrström (gpl-3.0-or-later)
+ Copyright (C) 2019-2025 Fredrik Öhrström (gpl-3.0-or-later)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -238,3 +238,8 @@ namespace
 // telegram=|3e44b6108707320001027a380030052f2f0C7830253390066D6872141239400E031891690000000E833C9265010000000B2B2602000BAB3C0000002F2F2F2F|
 // {"_":"telegram","current_power_consumption_kw": 0.226,"current_power_production_kw": 0,"device_date_time": "2024-09-18 20:50:40","id": "00320787","media": "electricity","meter": "amiplus","name": "MyElectricity4","timestamp": "1111-11-11T11:11:11Z","total_energy_consumption_kwh": 699.118,"total_energy_production_kwh": 16.592}
 // |MyElectricity4;00320787;699.118;0.226;16.592;0;null;null;null;null;null;null;null;null;null;1111-11-11 11:11.11
+
+// Test: MyElectricity5 amiplus 56914504 NOKEY
+// telegram=|9e4401060445915601027a3d0390052f2f066dc076091935800c78044591560e032088300000008e10032088300000008e20030000000000008e30030000000000008e8010030000000000000e833c2702000000008e10833c2702000000008e20833c0000000000008e30833c0000000000008e8010833c0000000000000afdc8fc0136240afdc8fc0262240afdc8fc0389222f2f2f2f2f2f2f2f2f2f2f2f|
+// {"_":"telegram","media":"electricity","meter":"amiplus","name":"MyElectricity5","id":"56914504","total_energy_consumption_kwh":308.82,"total_energy_consumption_tariff_1_kwh":308.82,"total_energy_consumption_tariff_2_kwh":0,"total_energy_consumption_tariff_3_kwh":0,"total_energy_production_kwh":0.227,"total_energy_production_tariff_1_kwh":0.227,"total_energy_production_tariff_2_kwh":0,"total_energy_production_tariff_3_kwh":0,"voltage_at_phase_1_v":243.6,"voltage_at_phase_2_v":246.2,"voltage_at_phase_3_v":228.9,"device_date_time":"2024-05-25 09:54:00","timestamp":"1111-11-11T11:11:11Z"}
+// |MyElectricity5;56914504;308.82;null;0.227;null;243.6;246.2;228.9;308.82;0;0;0.227;0;0;1111-11-11 11:11.11

--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -122,36 +122,6 @@ namespace
             .add(VIFCombinable::AtPhase3)
             );
 
-        addNumericFieldWithExtractor(
-            "voltage_at_phase_1",
-            "Voltage at phase L1.",
-            DEFAULT_PRINT_PROPERTIES,
-            Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
-            FieldMatcher::build()
-            .set(DifVifKey("0AFDC8FC01"))
-            );
-
-        addNumericFieldWithExtractor(
-            "voltage_at_phase_2",
-            "Voltage at phase L2.",
-            DEFAULT_PRINT_PROPERTIES,
-            Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
-            FieldMatcher::build()
-            .set(DifVifKey("0AFDC8FC02"))
-            );
-
-        addNumericFieldWithExtractor(
-            "voltage_at_phase_3",
-            "Voltage at phase L3.",
-            DEFAULT_PRINT_PROPERTIES,
-            Quantity::Voltage,
-            VifScaling::None, DifSignedness::Signed,
-            FieldMatcher::build()
-            .set(DifVifKey("0AFDC8FC03"))
-            );
-
         addStringFieldWithExtractor(
             "device_date_time",
             "Device date time.",


### PR DESCRIPTION
OTUS3 meters from PGE use C8 vife for voltages.

For [example](https://wmbusmeters.org/analyze/9E4401060445915601027A3D0390052F2F066DC076091935800C78044591560E032088300000008E10032088300000008E20030000000000008E30030000000000008E8010030000000000000E833C2702000000008E10833C2702000000008E20833C0000000000008E30833C0000000000008E8010833C0000000000000AFDC8FC0136240AFDC8FC0262240AFDC8FC0389222F2F2F2F2F2F2F2F2F2F2F2F)