### PR TITLE
Add new IDs for qwater and qheat drivers

### DIFF
--- a/src/driver_qheat.cc
+++ b/src/driver_qheat.cc
@@ -37,6 +37,7 @@ namespace
         di.addDetection(MANUFACTURER_QDS, 0x04,  0x23);
         di.addDetection(MANUFACTURER_QDS, 0x04,  0x46);
         di.addDetection(MANUFACTURER_QDS, 0x37,  0x23);
+        di.addDetection(MANUFACTURER_QDS, 0x37,  0x47);
         di.usesProcessContent();
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
     });

--- a/src/driver_qwater.cc
+++ b/src/driver_qwater.cc
@@ -38,6 +38,7 @@ namespace
         di.setMeterType(MeterType::WaterMeter);
         di.addLinkMode(LinkMode::S1);
         di.addDetection(MANUFACTURER_QDS, 0x37,  0x33);
+        di.addDetection(MANUFACTURER_QDS, 0x37,  0x35);
         di.addDetection(MANUFACTURER_QDS, 0x06,  0x16);
         di.addDetection(MANUFACTURER_QDS, 0x07,  0x16);
         di.addDetection(MANUFACTURER_QDS, 0x06,  0x17);


### PR DESCRIPTION
Hello, 

I recently got installed new meters for cold water and heat which are not autodetected, so I'm adding their IDs.
Example telegrams below.

Qwater:
```
Received telegram from: 37439212
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Radio converter (meter side) (0x37)
                   ver: 0x35
                device: rtlwmbus[]
                  rssi: 74 dBm
                driver: qwater
telegram=|_5344934412924337353778077912924337934435070DFF5F3500828A0000100007C113FFFF966600001F3C000000003E3419580000008000800080008000800080008000005A0094009C00BB002F046D010F3235|+18

Received telegram from: 37432649
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Radio converter (meter side) (0x37)
                   ver: 0x35
                device: rtlwmbus[]
                  rssi: 46 dBm
                driver: qwater
telegram=|_5344934449264337353778077949264337934435070DFF5F350082560000110007C113FFFF245300001F3C210400003E348946000000800080008000800080008000002A0066005F00730072002F046D000F3235|+20
```
Qheat:
```
Received telegram from: 68204641
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Radio converter (meter side) (0x37)
                   ver: 0x47
                device: rtlwmbus[]
                  rssi: 51 dBm
                driver: qheat
telegram=|_58449344414620684737780779414620689344470C0DFF5F3500825A00000E0007C00DFFFF310803001F3C036800003E34310803000080008000800080008000800000931A92293128190C00002F02FD170000046D000F3235|+2

Received telegram from: 68204641
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Radio converter (meter side) (0x37)
                   ver: 0x47
      Concerning meter: 68204641
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Heat volume at inlet meter (0x0c)
                   ver: 0x47
                device: rtlwmbus[]
                  rssi: 53 dBm
                driver: qheat
telegram=|_4144934441462068473772414620689344470C5B0000200C0D310803004C0D03680000426C1F3CCC080D31080300C2086C3E3402FD170000326CFFFF046D000F3235|+17
```

Thanks!