### PR TITLE
Update driver_qwater.cc - Qundis Qwater 5.5 2025

### DIFF
--- a/src/driver_qwater.cc
+++ b/src/driver_qwater.cc
@@ -46,6 +46,8 @@ namespace
         di.addDetection(MANUFACTURER_QDS, 0x06,  0x18);
         di.addDetection(MANUFACTURER_QDS, 0x07,  0x18);
         di.addDetection(MANUFACTURER_QDS, 0x07,  0x19);
+        di.addDetection(MANUFACTURER_QDS, 0x06,  0x1a);
+        di.addDetection(MANUFACTURER_QDS, 0x07,  0x1a);
         di.addDetection(MANUFACTURER_QDS, 0x06,  0x35);
         di.addDetection(MANUFACTURER_QDS, 0x07,  0x35);
         di.usesProcessContent();


### PR DESCRIPTION
Added version identification for the new water meters I just got (cold and warm water) - prodution year 2025:
Qundis "Qwater 5.5" WME-010T-1011 00V00 (cold water)
Qundis "Qwater 5.5" WME-011T-1011 00V00 (warm water)

Let me know if you need some telegram data / logs for adding tests, or if this is enough.

```
(meter) warmwater: meter detection did not match the selected driver qwater! correct driver is: unknown!
(meter) Not printing this warning again for id: 60101451 mfct: (QDS) Qundis, Germany (0x4493) type: Warm Water (30°C-90°C) meter (0x06) ver: 0x1a
--
(meter) coldwater: meter detection did not match the selected driver qwater! correct driver is: wme5
(meter) Not printing this warning again for id: 60113189 mfct: (QDS) Qundis, Germany (0x4493) type: Water meter (0x07) ver: 0x1a  
```