### PR TITLE
axioma to use q400 driver

### DIFF
--- a/src/driver_q400.cc
+++ b/src/driver_q400.cc
@@ -30,7 +30,7 @@ namespace
         di.setDefaultFields("name,id,total_m3,timestamp");
         di.setMeterType(MeterType::WaterMeter);
         di.addLinkMode(LinkMode::T1);
-        di.addDetection(MANUFACTURER_AXI, 0x07,  0x10);
+        di.addDetection(MANUFACTURER_AXI, 0x07,  0x01);
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
     });
 


### PR DESCRIPTION
By changing 0x10 to 0x01 it works with my axioma water-meter.
di.addDetection(MANUFACTURER_AXI, 0x07,  0x01);

I don't know if it was a typo or both versions exist.