### PR TITLE
Fix issue 1559 - Correct calculation of expected length when AMB8465 is in CMD mode

### DIFF
--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -659,8 +659,8 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
         payload_len = data[2];
         *payload_len_out = payload_len;
         *payload_offset = 3;
-        // FF CMD len payload [RSSI] CS
-        *frame_length = 4 + payload_len + rssi_len;
+        // FF CMD len payload [RSSI] CS (Note, RSSI already included in the payload_len if present.)
+        *frame_length = 4 + payload_len;
         if (data.size() < *frame_length)
         {
             debug("(amb8465) not enough bytes yet, partial command response %d %d.\n", data.size(), *frame_length);


### PR DESCRIPTION
payload_len in CMD mode already includes length of RSSI if present.  Existing calculation added an extra byte, meaning messages were never completed, and instead discarded.  Fix is just to remove the + rssi_len.  Tested this morning on Debian.