### PR TITLE
Fixes for the KEM importer

### DIFF
--- a/utils/kem-import.py
+++ b/utils/kem-import.py
@@ -178,6 +178,7 @@ def print_meter(meterName,meterType,meterNum,meterSerial,meterVendor,meterConfig
         if (wmbusmeters_driver is not None):
             try:
                 f = open(args.config+meterSerial, 'w')
+                f.write("# %s type %s config %s\n" % (meterName, meterModel, meterConfig))
                 f.write("name=%s\n" % (meterNum))
                 f.write("driver=%s\n" % (wmbusmeters_driver))
                 f.write("id=%s\n" % (meterSerial))

--- a/utils/kem-import.py
+++ b/utils/kem-import.py
@@ -58,7 +58,7 @@ argparser.add_argument("-o", "--output", type=str, action='store', dest='output'
 args = argparser.parse_args()
 
 # adjust the config folder location to full target path
-args.config = args.config.strip(os.path.sep) + '/etc/wmbusmeters.d/'
+args.config = os.path.join(args.config, 'etc/wmbusmeters.d/')
 
 
 # test if input file exists

--- a/utils/kem-import.py
+++ b/utils/kem-import.py
@@ -159,8 +159,8 @@ def print_meter(meterName,meterType,meterNum,meterSerial,meterVendor,meterConfig
         wmbusmeters_driver = 'multical21'
     elif (meterName == 'MC603') and (meterModel.startswith('603')): 
         wmbusmeters_driver = 'multical603'
-    elif (meterName == 'KWM2210'): 
-        wmbusmeters_driver = 'flowiq2200'
+    elif meterName.startswith('KWM'):
+        wmbusmeters_driver = 'kamwater'
     else:
         wmbusmeters_driver = None
 


### PR DESCRIPTION
### KEM import: fix working with relative paths
    
Previously, the default behavior would take an "absolute path" such as `/home/foo/wmbusmeters`, strip the leading slash, which yields `home/foo/wmbusmeters`, and use that as a path relative to the current working directory. This in turn created files on disk named, e.g., `/home/foo/wmbusmeters/home/foo/wmbusmeters/etc/wmbusmeters.d/12345678`.

### KEM: store meter type/config as a comment as well
    
 Right now these fields are of no use for wmbusmeters, but I think it's generally useful to keep information about the configuration of any given device. Given that Kamstrup decided to put this info into the KEM  files, let's at least put that into a comment field.

### KEM: generate a more generic config for modern Kamstrup water meters
    
The meter IDs are a bit more generic, so let's detect them based on a generic prefix. Also point to a generic driver name, not to an alias that implies that it's a specific driver for an older generation of meters.