### PR TITLE
chore: set optimization to -O2, set -flto and -fdump-tree-optimized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ DEFAULT_CONF_DIR?=/etc
 DEFAULT_DEAMON_DRIVER_DOWNLOAD_DIR?=/var/lib/wmbusmeters/wmbusmeters.drivers.d/downloaded
 DEFAULT_USER_DRIVER_DOWNLOAD_DIR?=.local/share/wmbusmeters/wmbusmeters.drivers.d
 
+DUMP_FLAGS=-fdump-tree-optimized
+
 include $(wildcard build/*/spec.gmk)
 
 ifeq (,$(CONF_NAME))
@@ -74,7 +76,7 @@ else
         endif
     else
         # Release build
-        DEBUG_FLAGS=-O3 -g
+        DEBUG_FLAGS=-O2 -g -flto
         STRIP_BINARY=cp $(BUILD)/wmbusmeters $(BUILD)/wmbusmeters.g; $(STRIP) $(BUILD)/wmbusmeters
         GCOV=To_run_gcov_add_DEBUG=true
     endif
@@ -162,12 +164,10 @@ LDFLAGS  += $(LIBXML_LIBS) $(LIBRTLSDR_LIBS) $(LIBUSB_LIBS)
 #endif
 
 $(BUILD)/%.o: src/%.cc $(wildcard src/%.h)
-#	$(CXX) $(CXXFLAGS) $< -c -E > $@.src
-	$(CXX) $(CXXFLAGS) $< -MMD -c -o $@
+	$(CXX) $(CXXFLAGS) $(DUMP_FLAGS) $< -MMD -c -o $@
 
 $(BUILD)/%.o: src/%.c $(wildcard src/%.h)
-#	$(CXX) $(CXXFLAGS) $< -c -E > $@.src
-	$(CXX) -fpermissive $(CXXFLAGS)  $< -MMD -c -o $@
+	$(CXX) -fpermissive $(CXXFLAGS) $(DUMP_FLAGS)  $< -MMD -c -o $@
 
 PROG_OBJS:=\
 	$(BUILD)/address.o \


### PR DESCRIPTION
Optimization level -O3 is too excessive  and extend the compile time unnecessarily. Potential gains, if there are any, are neglectable.

Activating -flto reduces the size of the final release executable by about 500 kb.

-fdump-tree-optimized "dumps" the preprocessed and by the compiler generated constexpr files in the build-folder. This can be used to examine potential performance and size improvements.