### PR TITLE
fix: implementation of "exp", rename to "pow" and change operator character to "**"

### DIFF
--- a/src/formula.cc
+++ b/src/formula.cc
@@ -377,7 +377,7 @@ const char *toString(TokenType tt)
     case TokenType::BOR:  return "BOR";
     case TokenType::LAND: return "LAND";
     case TokenType::LOR:  return "LOR";
-    case TokenType::EXP: return "EXP";
+    case TokenType::POW: return "POW";
     case TokenType::SQRT: return "SQRT";
     case TokenType::ROUND: return "ROUND";
     case TokenType::FLOOR: return "FLOOR";
@@ -710,7 +710,7 @@ size_t FormulaImplementation::findBitwiseOr(size_t i)
     return 1;
 }
 
-size_t FormulaImplementation::findExp(size_t i)
+size_t FormulaImplementation::findPow(size_t i)
 {
     if (i+1 >= formula_.length()) return 0;
     if (formula_[i] == '*' && formula_[i+1] == '*') return 2;
@@ -906,8 +906,8 @@ bool FormulaImplementation::tokenize()
         len = findBitwiseOr(i);
         if (len > 0) { tokens_.push_back(Token(TokenType::BOR, i, len)); i+=len; continue; }
 
-        len = findExp(i);
-        if (len > 0) { tokens_.push_back(Token(TokenType::EXP, i, len)); i+=len; continue; }
+        len = findPow(i);
+        if (len > 0) { tokens_.push_back(Token(TokenType::POW, i, len)); i+=len; continue; }
 
         len = findSqrt(i);
         if (len > 0) { tokens_.push_back(Token(TokenType::SQRT, i, len)); i+=len; continue; }
@@ -1103,7 +1103,7 @@ size_t FormulaImplementation::parseOps(size_t i)
         return next;
     }
 
-    if (tok->type == TokenType::EXP)
+    if (tok->type == TokenType::POW)
     {
         size_t next = parseOps(i+1);
         if (!valid_) return next;

--- a/src/formula.cc
+++ b/src/formula.cc
@@ -178,7 +178,7 @@ double NumericFormulaExponentiation::calculate(SIUnit to_siunit)
     double v {};
     siunit().convertTo(p, to_siunit, &v);
 
-    debug("(formula) %g <-- %g <-- pow %g ^ %g\n", v, p, l, r);
+    debug("(formula) %g <-- %g <-- pow %g ** %g\n", v, p, l, r);
     return v;
 }
 
@@ -596,10 +596,10 @@ size_t FormulaImplementation::findTimes(size_t i)
 {
     if (i >= formula_.length()) return 0;
 
-    char c = formula_[i];
-    if (c == '*') return 1;
+    if (formula_[i] != '*') return 0;
+    if (i+1 < formula_.length() && formula_[i+1] == '*') return 0;
 
-    return 0;
+    return 1;
 }
 
 size_t FormulaImplementation::findDiv(size_t i)
@@ -712,15 +712,9 @@ size_t FormulaImplementation::findBitwiseOr(size_t i)
 
 size_t FormulaImplementation::findExp(size_t i)
 {
+    if (i+1 >= formula_.length()) return 0;
+    if (formula_[i] == '*' && formula_[i+1] == '*') return 2;
     return 0;
-    /*
-    if (i >= formula_.length()) return 0;
-
-    char c = formula_[i];
-    if (c == '^') return 1;
-
-    return 0;
-    */
 }
 
 size_t FormulaImplementation::findSqrt(size_t i)
@@ -1632,17 +1626,13 @@ void FormulaImplementation::doExponentiation()
 {
     assert(op_stack_.size() >= 2);
 
-//    SIUnit right_siunit = topOp()->siunit();
-
     unique_ptr<NumericFormula> right_node = popOp();
 
     SIUnit left_siunit = topOp()->siunit();
 
     unique_ptr<NumericFormula> left_node = popOp();
 
-    pushOp(new NumericFormulaDivision(this, left_siunit, left_node, right_node));
-
-//    assert(canConvert(left_siunit, right_siunit));
+    pushOp(new NumericFormulaExponentiation(this, left_siunit, left_node, right_node));
 }
 
 void FormulaImplementation::doSquareRoot()

--- a/src/formula_implementation.h
+++ b/src/formula_implementation.h
@@ -164,7 +164,7 @@ struct NumericFormulaExponentiation : public NumericFormulaPair
     NumericFormulaExponentiation(FormulaImplementation *f, SIUnit siu,
                                  std::unique_ptr<NumericFormula> &a,
                                  std::unique_ptr<NumericFormula> &b)
-        : NumericFormulaPair(f, siu, a, b, "EXP", "**") {}
+        : NumericFormulaPair(f, siu, a, b, "POW", "**") {}
 
     double calculate(SIUnit to);
 
@@ -400,7 +400,7 @@ enum class TokenType
     BOR,
     LAND,
     LOR,
-    EXP,
+    POW,
     SQRT,
     ROUND,
     FLOOR,
@@ -507,7 +507,7 @@ struct FormulaImplementation : public Formula
     size_t findBitwiseOr(size_t i);
     size_t findLogicalAnd(size_t i);
     size_t findLogicalOr(size_t i);
-    size_t findExp(size_t i);
+    size_t findPow(size_t i);
     size_t findSqrt(size_t i);
     size_t findRound(size_t i);
     size_t findFloor(size_t i);

--- a/src/formula_implementation.h
+++ b/src/formula_implementation.h
@@ -164,7 +164,7 @@ struct NumericFormulaExponentiation : public NumericFormulaPair
     NumericFormulaExponentiation(FormulaImplementation *f, SIUnit siu,
                                  std::unique_ptr<NumericFormula> &a,
                                  std::unique_ptr<NumericFormula> &b)
-        : NumericFormulaPair(f, siu, a, b, "EXP", "^") {}
+        : NumericFormulaPair(f, siu, a, b, "EXP", "**") {}
 
     double calculate(SIUnit to);
 

--- a/src/testinternals.cc
+++ b/src/testinternals.cc
@@ -2856,6 +2856,7 @@ void test_formulas_extended_ops()
     FormulaImplementation fi;
 
     test_formula_value(&fi, NULL, "7counter % 4counter", 3, Unit::COUNTER);
+    test_formula_value(&fi, NULL, "2counter ** 3counter", 8, Unit::COUNTER);
     test_formula_value(&fi, NULL, "3counter << 4counter", 48, Unit::COUNTER);
     test_formula_value(&fi, NULL, "48counter >> 4counter", 3, Unit::COUNTER);
     test_formula_value(&fi, NULL, "floor(100.999 kwh)", 100, Unit::KWH);


### PR DESCRIPTION
exponentiation was since for ever broken.

I fixed it and because it never worked in the first place, took the chance and replaced the operator name from `exp` to `pow` and the "^" character to "**" characters. 

As it was broken from the beginning, there is no chance of introducing a regression. 

The name `exp` and `exponentiation` is misleading, because exponentiation means e^x, while e is Eulers number, and pow means x^y. 

The reason for changing the character is the problem, that in c-like languages `^` is used for XOR. C and C++ do not have an pow operator, while other languages like python and javascript use the `**`. I guess because  exactly the same reason, because `^` would collide with the XOR operator. 
