### PR TITLE
fix: make should not set `-fdump-tree-optimized` if on non linux system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ DEFAULT_CONF_DIR?=/etc
 DEFAULT_DEAMON_DRIVER_DOWNLOAD_DIR?=/var/lib/wmbusmeters/wmbusmeters.drivers.d/downloaded
 DEFAULT_USER_DRIVER_DOWNLOAD_DIR?=.local/share/wmbusmeters/wmbusmeters.drivers.d
 
-DUMP_FLAGS=-fdump-tree-optimized
+DUMP_FLAGS=
+
+ifeq ($(shell uname),Linux)
+    DUMP_FLAGS=-fdump-tree-optimized
+endif
 
 include $(wildcard build/*/spec.gmk)
 


### PR DESCRIPTION
The CI is red, because the compiler for mac is not know `-fdump-tree-optimized`. So we just add `-fdump-tree-optimized` if we are on Linux