### PR TITLE
chore: remove error-artifact

### DIFF
--- a/src/log.cc
+++ b/src/log.cc
@@ -294,17 +294,6 @@ void trace_int(const char* fmt, ...) {
     exit(__status);
 }
 
-
-// [[noreturn]] void error(const char* fmt, ...)
-// {
-//     va_list args;
-//     va_start(args, fmt);
-//     output_stuff(LOG_ERR, true, fmt, args);
-//     va_end(args);
-//     exitHandler(0);
-//     exit(EXIT_FAILURE);
-// }
-
 void logTelegram(vector<uchar> &original, vector<uchar> &parsed, int header_size, int suffix_size)
 {
     if (isLogTelegramsEnabled())

--- a/src/log.h
+++ b/src/log.h
@@ -36,7 +36,6 @@ void notice_timestamp(const char* fmt, ...);
 
 void warning(const char* fmt, ...);
 
-// [[noreturn]] void error(const char* fmt, ...);
 [[noreturn]] void error(int __status, const char* fmt, ...);
 
 #define verbose(...) { if (isVerboseEnabled()) { verbose_int(__VA_ARGS__); } }


### PR DESCRIPTION
error should always use a exit-code. previous commit did not remove the overloaded error function but commented it out. this removes the commented out code.