### PR TITLE
chore: remove `language()` from util.cc

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1956,32 +1956,6 @@ bool endsWith(const std::string& str, const std::string& suffix)
     return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
 }
 
-string lang_;
-
-const std::string &language()
-{
-    if (lang_.length() > 0) return lang_;
-
-    const char *la = getenv("LANG");
-    if (!la || strlen(la) < 2)
-    {
-        lang_ = "en";
-    }
-    else
-    {
-        if (la[2] == '_' || la[2] == 0)
-        {
-            lang_ = string(la, la+2);
-        }
-        else
-        {
-            lang_ = "en";
-        }
-    }
-
-    return lang_;
-}
-
 TestBit toTestBit(const char *s)
 {
     if (!strcmp(s, "Set")) return TestBit::Set;

--- a/src/util.h
+++ b/src/util.h
@@ -276,9 +276,6 @@ int toMfctCode(char a, char b, char c);
 
 bool is_lowercase_alpha_num_underscore(const char *text);
 
-// The language that the user expects driver and other messages in.
-const std::string &language();
-
 TestBit toTestBit(const char *s);
 
 #ifndef FUZZING


### PR DESCRIPTION
`language()` from util.cc is not used anywhere in the code.