### PR TITLE
fix: run specific hub workflows only on wmbusmeters/wmbusmeters repo

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'wmbusmeters/wmbusmeters'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build_snap.yml
+++ b/.github/workflows/build_snap.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-and-release:
+    if: github.repository == 'wmbusmeters/wmbusmeters'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository == 'wmbusmeters/wmbusmeters'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10

--- a/.github/workflows/trigger_ha_addon.yml
+++ b/.github/workflows/trigger_ha_addon.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   trigger_ha_addon_build:
+    if: github.repository == 'wmbusmeters/wmbusmeters'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/update_manufacturers.yml
+++ b/.github/workflows/update_manufacturers.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'wmbusmeters/wmbusmeters'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Committing and pushing on forks result in failed workflow runs, as those workflows should only run i then wmbusmeters/wmbusmeters repo.