### PR TITLE
fix: only store compact formats when they have sane values

### DIFF
--- a/src/dvparser.cc
+++ b/src/dvparser.cc
@@ -1384,12 +1384,16 @@ bool parseDV(Telegram *t,
         }
     }
 
-    uint16_t hash = crc16_EN13757(safeButUnsafeVectorPtr(format_bytes), format_bytes.size());
-
     if (data_has_difvifs) {
-        if (hash_to_format_.count(hash) == 0) {
-            hash_to_format_[hash] = format_bytes;
-            debug("(dvparser) found new format \"%s\" with hash %x, remembering!\n", bin2hex(format_bytes).c_str(), hash);
+        size_t format_bytes_len = format_bytes.size();
+
+        if (format_bytes_len != 0) {
+            uint16_t hash = crc16_EN13757(safeButUnsafeVectorPtr(format_bytes), format_bytes_len);
+                
+            if (hash_to_format_.count(hash) == 0) {
+                hash_to_format_[hash] = format_bytes;
+                debug("(dvparser) found new format \"%s\" with hash %x, remembering!\n", bin2hex(format_bytes).c_str(), hash);
+            }
         }
     }
 


### PR DESCRIPTION
while scanning for compact formats, i realize that i get alot of 0xffff frames because format_bytes is empty.

Avoid this by adding sanity checks.