### PR TITLE
feat: unify crc logic, add ability to create new crc16 variants

### DIFF
--- a/src/crc16.cc
+++ b/src/crc16.cc
@@ -15,71 +15,64 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include"crc16.h"
-#include<cassert>
+#include "crc16.h"
 
-#define CRC16_EN_13757 0x3D65
+#include <cassert>
 
-static uint16_t crc16_EN13757_per_byte(uint16_t crc, uchar b)
+uint16_t crc16(uint16_t poly, uint16_t init, uchar *data, size_t len)
 {
-    unsigned char i;
-
-    for (i = 0; i < 8; i++) {
-
-        if (((crc & 0x8000) >> 8) ^ (b & 0x80)){
-            crc = (crc << 1)  ^ CRC16_EN_13757;
-        }else{
-            crc = (crc << 1);
-        }
-
-        b <<= 1;
-    }
-
-    return crc;
-}
-
-uint16_t crc16_EN13757(uchar *data, size_t len)
-{
-    uint16_t crc = 0x0000;
+    uint16_t crc = init;
 
     assert(len == 0 || data != NULL);
 
-    for (size_t i=0; i<len; ++i)
+    for (size_t i = 0; i < len; i++)
     {
-        crc = crc16_EN13757_per_byte(crc, data[i]);
+        uchar b = data[i];
+        for (int j = 0; j < 8; j++)
+        {
+            if (((crc & 0x8000) >> 8) ^ (b & 0x80))
+            {
+                crc = (crc << 1) ^ poly;
+            }
+            else
+            {
+                crc = (crc << 1);
+            }
+            b <<= 1;
+        }
     }
 
-    return (~crc);
+    return crc;
 }
 
-#define CRC16_INIT_VALUE 0xFFFF
-#define CRC16_GOOD_VALUE 0x0F47
-#define CRC16_POLYNOM    0x8408
+#define CRC16_EN_13757_INIT_VALUE 0x0000
+#define CRC16_EN_13757_POLYNOM    0x3D65
+
+uint16_t crc16_EN13757(uchar *data, size_t len)
+{
+    return ~crc16(CRC16_EN_13757_POLYNOM, CRC16_EN_13757_INIT_VALUE, data, len);
+}
+
+/*
+ CCITT stands for "Comité Consultatif International Télégraphique et
+ Téléphonique", also known as "International Telecommunication Union
+ Telecommunication Standardization Sector", or short "ITU-T".
+ 
+ This CRC16 variation is used by im871a for its serial communication.
+*/ 
+
+#define CRC16_CCITT_INIT_VALUE 0xFFFF
+#define CRC16_CCITT_POLYNOM    0x1021
+#define CRC16_CCITT_GOOD_VALUE 0x0F47
 
 uint16_t crc16_CCITT(uchar *data, uint16_t length)
 {
-    uint16_t initVal = CRC16_INIT_VALUE;
-    uint16_t crc = initVal;
-    while(length--)
-    {
-        int bits = 8;
-        uchar byte = *data++;
-        while(bits--)
-        {
-            if((byte & 1) ^ (crc & 1))
-            {
-                crc = (crc >> 1) ^ CRC16_POLYNOM;
-            }
-            else
-                crc >>= 1;
-            byte >>= 1;
-        }
-    }
-    return crc;
+    return crc16(CRC16_CCITT_POLYNOM, CRC16_CCITT_INIT_VALUE, data, length);
 }
 
 bool crc16_CCITT_check(uchar *data, uint16_t length)
 {
     uint16_t crc = ~crc16_CCITT(data, length);
-    return crc == CRC16_GOOD_VALUE;
+    return crc == CRC16_CCITT_GOOD_VALUE;
 }
+

--- a/src/crc16.h
+++ b/src/crc16.h
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <cstddef>
 
+uint16_t crc16(uint16_t poly, uint16_t init, uchar *data, size_t len);
+
 uint16_t crc16_EN13757(uchar *data, size_t len);
 
 // This crc is used by im871a for its serial communication.

--- a/src/testinternals.cc
+++ b/src/testinternals.cc
@@ -195,6 +195,44 @@ void test_crc()
     if (crc != 0xc2b7) {
         printf("ERROR! %4x should be c2b7\n", crc);
     }
+
+    block[0]='1';
+    block[1]='2';
+    block[2]='3';
+    block[3]='4';
+    block[4]='5';
+    block[5]='6';
+    block[6]='7';
+    block[7]='8';
+    block[8]='9';
+
+    crc = crc16_CCITT(block, 9);
+
+    if (crc != 0x29B1) {
+        printf("ERROR! CCITT %04x should be 29b1\n", crc);
+    }
+
+    // Generic overload: crc16_EN13757(data,len) == ~crc16(0x3D65, 0x0000, data, len)
+    block[0]='1';
+    block[1]='2';
+    block[2]='3';
+    block[3]='4';
+    block[4]='5';
+    block[5]='6';
+    block[6]='7';
+    block[7]='8';
+    block[8]='9';
+
+    crc = ~crc16(0x3D65, 0x0000, block, 9);
+    if (crc != 0xc2b7) {
+        printf("ERROR! generic crc16(EN13757) %04x should be c2b7\n", crc);
+    }
+    // Apator-specific variant (POLY=0x41A5, INIT=0x5B25) used in methods b and c.
+    // No real test vector available yet; just verify the call compiles and runs.
+    uint16_t apator_crc = crc16(0x41A5, 0x5B25, block, 9);
+    (void)apator_crc;
+
+    printf("OK: Test CRC16\n");
 }
 
 bool tst_parse(const char *data, std::unordered_map<std::string,std::pair<int,DVEntry>> *dv_entries, int testnr)

--- a/src/util.h
+++ b/src/util.h
@@ -150,13 +150,6 @@ int parseTime(const std::string& time);
 bool isInsideTimePeriod(time_t now, std::string periods);
 bool isValidTimePeriod(const std::string& periods);
 
-/*
-uint16_t crc16_EN13757(uchar *data, size_t len);
-
-// This crc is used by im871a for its serial communication.
-uint16_t crc16_CCITT(uchar *data, uint16_t length);
-bool     crc16_CCITT_check(uchar *data, uint16_t length);
-*/
 
 // Check if buffer is all SLIP END = 0xc0.
 bool slipAllEND(std::vector<uchar>& msg);


### PR DESCRIPTION
This PR unifies `crc16_EN13757()` and `crc16_CCITT()` logic, by using in both cases the MSB  method.

I personally would have preferred moving the logic of the new `uint16_t crc16(uint16_t poly, uint16_t init, uchar *data, size_t len)` into crc16.h and mark it as `__inline`. As such it would not be possible to call the `crc16()` in different places and would force the compiler to definetly inline it at compile time.

Anyhow: There are afaik two manufacturers, who use special CRC16 variants, IIRC it is kamstrup and apator.  So this PR enables developers to add their CRC16 variants to wmbusmeters-