### PR TITLE
feat: add `default_keys` to xmq.

### DIFF
--- a/src/driver_dynamic.cc
+++ b/src/driver_dynamic.cc
@@ -135,6 +135,7 @@ bool DriverDynamic::load(DriverInfo *di, const string &file_name, const char *co
         xmqForeach(doc, "/driver/detect/mvt", (XMQNodeCallback)add_detect, di);
         xmqForeach(doc, "/driver/compact_frame_formats/difvif", (XMQNodeCallback)add_compact_frame_format, di);
         xmqForeach(doc, "/driver/mfct_tpl_status_bits", (XMQNodeCallback)add_mfct_tpl_status, di);
+        xmqForeach(doc, "/driver/default_keys/key", (XMQNodeCallback)add_default_key, di);
 
         check_detection_triplets(di, file);
 
@@ -711,6 +712,22 @@ XMQProceed DriverDynamic::add_mfct_tpl_status(XMQDoc *doc, XMQNodePtr node, Driv
     lookup.add(rule);
     di->mfctTPLStatusBits() = lookup;
 
+    return XMQ_CONTINUE;
+}
+
+XMQProceed DriverDynamic::add_default_key(XMQDoc *doc, XMQNodePtr node, DriverInfo *di)
+{
+    const char *key_s = xmqGetStringRel(doc, ".", node);
+    if (!key_s) return XMQ_CONTINUE;
+
+    vector<uchar> key;
+    if (!hex2bin(key_s, &key) || key.size() != 16)
+    {
+        warning("(driver) invalid default_key '%s' in %s (must be 32 hex chars)\n",
+                key_s, di->getDynamicFileName().c_str());
+        return XMQ_CONTINUE;
+    }
+    di->addDefaultKey(key);
     return XMQ_CONTINUE;
 }
 

--- a/src/driver_dynamic.h
+++ b/src/driver_dynamic.h
@@ -35,9 +35,10 @@ struct DriverDynamic : public MeterCommonImplementation
 
     static XMQProceed add_lookup(XMQDoc *doc, XMQNodePtr lookup, DriverDynamic *dd);
     static XMQProceed add_map(XMQDoc *doc, XMQNodePtr map, DriverDynamic *dd);
-
+    
     static XMQProceed add_mfct_tpl_status(XMQDoc *doc, XMQNodePtr node, DriverInfo *di);
     static XMQProceed add_mfct_tpl_status_map(XMQDoc *doc, XMQNodePtr map, Translate::Rule *rule);
+    static XMQProceed add_default_key(XMQDoc *doc, XMQNodePtr node, DriverInfo *di);
 
     const std::string &fileName() { return file_name_; }
 

--- a/src/meters.cc
+++ b/src/meters.cc
@@ -502,6 +502,10 @@ MeterCommonImplementation::MeterCommonImplementation(MeterInfo &mi,
     {
         hex2bin(mi.key, &meter_keys_.confidentiality_key);
     }
+    if (!meter_keys_.hasConfidentialityKey())
+    {
+        meter_keys_.default_keys = di.defaultKeys();
+    }
     for (auto s : mi.shells)
     {
         addShellMeterUpdated(s);

--- a/src/meters.h
+++ b/src/meters.h
@@ -168,6 +168,7 @@ private:
     std::string dynamic_file_name_; // Name of actual loaded driver file.
     std::string dynamic_source_xmq_ {}; // A copy of the xmq used to create a dynamic driver.
     std::vector<std::pair<uint16_t,std::vector<uchar>>> compact_frame_formats_;
+    std::vector<std::vector<uchar>> default_keys_; // Default keys from driver XMQ; tried in order when no meter key is set.
 
 public:
     ~DriverInfo();
@@ -183,6 +184,8 @@ public:
     void addMVT(uint16_t mfct, uchar type, uchar ver) { mvts_.push_back({ mfct, ver, type }); }
     void addCompactFrameFormat(uint16_t sig, std::vector<uchar> difvif) { compact_frame_formats_.push_back({ sig, std::move(difvif) }); }
     const std::vector<std::pair<uint16_t,std::vector<uchar>>> &compactFrameFormats() { return compact_frame_formats_; }
+    void addDefaultKey(const std::vector<uchar> &key) { default_keys_.push_back(key); }
+    const std::vector<std::vector<uchar>> &defaultKeys() const { return default_keys_; }
     void usesProcessContent() { has_process_content_ = true; }
     void setMediaType(std::string m) { media_type_ = m; }
     const std::string &mediaType() { return media_type_; }

--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -1590,8 +1590,42 @@ bool Telegram::potentiallyDecrypt(vector<uchar>::iterator &pos)
         int num_encrypted_bytes = 0;
         int num_not_encrypted_at_end = 0;
 
-        bool ok = decrypt_TPL_AES_CBC_IV(this, frame, pos, meter_keys->confidentiality_key,
-                                         &num_encrypted_bytes, &num_not_encrypted_at_end);
+        bool ok = false;
+
+        if (!meter_keys->hasConfidentialityKey() &&
+            !meter_keys->default_keys.empty())
+        {
+            // No explicit meter key — try each driver-supplied default key in order.
+            for (const auto &candidate : meter_keys->default_keys)
+            {
+                vector<uchar> saved(pos, frame.end());
+                vector<uchar> trial_key = candidate;
+                int nenc = 0, ntrail = 0;
+                bool dec_ok = decrypt_TPL_AES_CBC_IV(this, frame, pos, trial_key, &nenc, &ntrail);
+                if (dec_ok && pos+1 < frame.end() && *(pos) == 0x2f && *(pos+1) == 0x2f)
+                {
+                    meter_keys->confidentiality_key = candidate;
+                    num_encrypted_bytes = nenc;
+                    num_not_encrypted_at_end = ntrail;
+                    ok = true;
+                    break;
+                }
+                // Wrong key — restore encrypted region and try the next one.
+                frame.erase(pos, frame.end());
+                frame.insert(frame.end(), saved.begin(), saved.end());
+            }
+            // Always clear: if a key matched it has been promoted to confidentiality_key
+            // so the remaining candidates are no longer needed. If all failed they
+            // should not be retried on the next telegram.
+            meter_keys->default_keys.clear();
+        }
+
+        if (!ok)
+        {
+            ok = decrypt_TPL_AES_CBC_IV(this, frame, pos, meter_keys->confidentiality_key,
+                                        &num_encrypted_bytes, &num_not_encrypted_at_end);
+        }
+
         if (!ok)
         {
             // No key supplied.

--- a/src/wmbus.h
+++ b/src/wmbus.h
@@ -352,7 +352,8 @@ struct MeterKeys
 {
     std::vector<uchar> confidentiality_key;
     std::vector<uchar> authentication_key;
-
+    std::vector<std::vector<uchar>> default_keys; // Driver-level fallback keys tried when no meter key is configured.
+    
     bool hasConfidentialityKey() { return confidentiality_key.size() > 0; }
     bool hasAuthenticationKey() { return authentication_key.size() > 0; }
 };


### PR DESCRIPTION
Adds the opportunity to add `default_keys` to xmq, which then can represent factory keys or keys which are widely used in an area.