### PR TITLE
`kamwater` improvements

### DIFF
--- a/drivers/src/kamwater.xmq
+++ b/drivers/src/kamwater.xmq
@@ -58,24 +58,24 @@ driver {
                 mask_bits       = 0xffffffff
                 default_message = OK
                 map {
-                    name  = DRY
-                    bit   = 0
-                    test  = Set
+                    name = DRY
+                    bit  = 0
+                    test = Set
                 }
                 map {
-                    name  = REVERSE
-                    bit   = 1
-                    test  = Set
+                    name = REVERSE
+                    bit  = 1
+                    test = Set
                 }
                 map {
-                    name  = LEAK
-                    bit   = 2
-                    test  = Set
+                    name = LEAK
+                    bit  = 2
+                    test = Set
                 }
                 map {
-                    name  = BURST
-                    bit   = 3
-                    test  = Set
+                    name = BURST
+                    bit  = 3
+                    test = Set
                 }
             }
         }
@@ -93,24 +93,24 @@ driver {
                 mask_bits       = 0x000f
                 default_message = OK
                 map {
-                    name  = DRY
-                    bit   = 0
-                    test  = Set
+                    name = DRY
+                    bit  = 0
+                    test = Set
                 }
                 map {
-                    name  = REVERSE
-                    bit   = 1
-                    test  = Set
+                    name = REVERSE
+                    bit  = 1
+                    test = Set
                 }
                 map {
-                    name  = LEAK
-                    bit   = 2
-                    test  = Set
+                    name = LEAK
+                    bit  = 2
+                    test = Set
                 }
                 map {
-                    name  = BURST
-                    bit   = 3
-                    test  = Set
+                    name = BURST
+                    bit  = 3
+                    test = Set
                 }
             }
         }
@@ -127,24 +127,24 @@ driver {
                 map_type  = BitToString
                 mask_bits = 0x000f
                 map {
-                    name  = DRY
-                    bit   = 0
-                    test  = Set
+                    name = DRY
+                    bit  = 0
+                    test = Set
                 }
                 map {
-                    name  = REVERSE
-                    bit   = 1
-                    test  = Set
+                    name = REVERSE
+                    bit  = 1
+                    test = Set
                 }
                 map {
-                    name  = LEAK
-                    bit   = 2
-                    test  = Set
+                    name = LEAK
+                    bit  = 2
+                    test = Set
                 }
                 map {
-                    name  = BURST
-                    bit   = 3
-                    test  = Set
+                    name = BURST
+                    bit  = 3
+                    test = Set
                 }
             }
         }

--- a/drivers/src/kamwater.xmq
+++ b/drivers/src/kamwater.xmq
@@ -5,16 +5,20 @@ driver {
     meter_type     = WaterMeter
     default_fields = name,id,status,total_m3,target_m3,timestamp
     detect {
+        // multical21
         mvt = KAM,1b,06
+
         // multical21
         mvt = KAM,1b,16
-        // multical21
+
+        // flowiq2200
         mvt = KAW,3a,16
+
         // flowiq2200
         mvt = KAW,3c,16
+
         // flowiq2200
         mvt = KAM,1d,16
-        // flowiq2200
     }
     compact_frame_formats {
         difvif = 02FF2004134413615B6167

--- a/drivers/src/kamwater.xmq
+++ b/drivers/src/kamwater.xmq
@@ -19,6 +19,12 @@ driver {
 
         // flowiq2200
         mvt = KAM,1d,16
+
+        // KWM2230 / 3230, warm
+        mvt = KAW,42,06
+
+        // KWM2230 / 3230, cold
+        mvt = KAW,42,16
     }
     compact_frame_formats {
         difvif = 02FF2004134413615B6167

--- a/drivers/src/kamwater.xmq
+++ b/drivers/src/kamwater.xmq
@@ -59,22 +59,22 @@ driver {
                 default_message = OK
                 map {
                     name  = DRY
-                    value = 0x01
+                    bit   = 0
                     test  = Set
                 }
                 map {
                     name  = REVERSE
-                    value = 0x02
+                    bit   = 1
                     test  = Set
                 }
                 map {
                     name  = LEAK
-                    value = 0x04
+                    bit   = 2
                     test  = Set
                 }
                 map {
                     name  = BURST
-                    value = 0x08
+                    bit   = 3
                     test  = Set
                 }
             }
@@ -94,22 +94,22 @@ driver {
                 default_message = OK
                 map {
                     name  = DRY
-                    value = 0x01
+                    bit   = 0
                     test  = Set
                 }
                 map {
                     name  = REVERSE
-                    value = 0x02
+                    bit   = 1
                     test  = Set
                 }
                 map {
                     name  = LEAK
-                    value = 0x04
+                    bit   = 2
                     test  = Set
                 }
                 map {
                     name  = BURST
-                    value = 0x08
+                    bit   = 3
                     test  = Set
                 }
             }
@@ -128,22 +128,22 @@ driver {
                 mask_bits = 0x000f
                 map {
                     name  = DRY
-                    value = 0x01
+                    bit   = 0
                     test  = Set
                 }
                 map {
                     name  = REVERSE
-                    value = 0x02
+                    bit   = 1
                     test  = Set
                 }
                 map {
                     name  = LEAK
-                    value = 0x04
+                    bit   = 2
                     test  = Set
                 }
                 map {
                     name  = BURST
-                    value = 0x08
+                    bit   = 3
                     test  = Set
                 }
             }

--- a/drivers/src/kamwater.xmq
+++ b/drivers/src/kamwater.xmq
@@ -77,6 +77,33 @@ driver {
                     bit  = 3
                     test = Set
                 }
+                map {
+                    name = TAMPER
+                    bit  = 4
+                    test = Set
+                }
+                map {
+                    name = LOW_BATTERY
+                    bit  = 5
+                    test = Set
+                }
+                map {
+                    name = LOW_ABIENT_TEMPERATURE
+                    bit  = 6
+                    test = Set
+                }
+                map {
+                    name = FLOW_ABOVE_Q4
+                    bit  = 7
+                    test = Set
+                }
+                // bit 8 is unused
+                map {
+                    name = NO_CONSUMPTION
+                    bit  = 9
+                    test = Set
+                }
+                // bit 10 is unused
             }
         }
         field {


### PR DESCRIPTION
The main goal is to modernize the status field parsing (#1951). So far, I've used the `bit` instead of `value`. When more of the proposed changes in the core driver/extractor are implemented, I'll be happy to make use of them.