### PR TITLE
chore: remove util.h from translatebits.h

### DIFF
--- a/src/lora_iu880b.cc
+++ b/src/lora_iu880b.cc
@@ -23,6 +23,7 @@
 #include"lora_iu880b.h"
 #include"serial.h"
 #include"threads.h"
+#include"util.h"
 
 #include"crypto/crc16.h"
 

--- a/src/mbus_rawtty.cc
+++ b/src/mbus_rawtty.cc
@@ -21,6 +21,7 @@
 #include"wmbus_common_implementation.h"
 #include"wmbus_utils.h"
 #include"serial.h"
+#include"util.h"
 
 #include<assert.h>
 #include<pthread.h>

--- a/src/meters.h
+++ b/src/meters.h
@@ -25,6 +25,7 @@
 #include"translatebits.h"
 #include"xmq.h"
 #include"wmbus.h"
+#include"util.h"
 
 #include<functional>
 #include<numeric>

--- a/src/translatebits.cc
+++ b/src/translatebits.cc
@@ -18,8 +18,8 @@
 #include"translatebits.h"
 #include"util.h"
 
-#include<assert.h>
-#include<string.h>
+#include<cassert>
+#include<cstring>
 
 using namespace Translate;
 using namespace std;

--- a/src/translatebits.h
+++ b/src/translatebits.h
@@ -18,8 +18,6 @@
 #ifndef TRANSLATEBITS_H
 #define TRANSLATEBITS_H
 
-#include"util.h"
-
 #include<cstdint>
 #include<string>
 #include<vector>

--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -23,6 +23,7 @@
 #include"wmbus_utils.h"
 #include"dvparser.h"
 #include"manufacturer_specificities.h"
+#include"util.h"
 
 #include"utils/alarm.h"
 #include"crypto/crc16.h"

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -23,6 +23,7 @@
 #include"wmbus_amb8465.h"
 #include"serial.h"
 #include"threads.h"
+#include"util.h"
 
 #include<assert.h>
 #include<pthread.h>

--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -21,6 +21,7 @@
 #include"wmbus_common_implementation.h"
 #include"wmbus_utils.h"
 #include"serial.h"
+#include"util.h"
 
 #include<assert.h>
 #include<fcntl.h>

--- a/src/wmbus_im871a.cc
+++ b/src/wmbus_im871a.cc
@@ -23,6 +23,7 @@
 #include"wmbus_im871a.h"
 #include"serial.h"
 #include"threads.h"
+#include"util.h"
 
 #include"crypto/crc16.h"
 

--- a/src/wmbus_iu891a.cc
+++ b/src/wmbus_iu891a.cc
@@ -23,6 +23,7 @@
 #include"wmbus_iu891a.h"
 #include"serial.h"
 #include"threads.h"
+#include"util.h"
 
 #include"crypto/crc16.h"
 

--- a/src/wmbus_rawtty.cc
+++ b/src/wmbus_rawtty.cc
@@ -21,6 +21,7 @@
 #include"wmbus_common_implementation.h"
 #include"wmbus_utils.h"
 #include"serial.h"
+#include"util.h"
 
 #include<assert.h>
 #include<pthread.h>

--- a/src/wmbus_rc1180.cc
+++ b/src/wmbus_rc1180.cc
@@ -21,6 +21,7 @@
 #include"wmbus_common_implementation.h"
 #include"wmbus_utils.h"
 #include"serial.h"
+#include"util.h"
 
 #include<assert.h>
 #include<fcntl.h>

--- a/src/wmbus_rtl433.cc
+++ b/src/wmbus_rtl433.cc
@@ -22,6 +22,7 @@
 #include"wmbus_utils.h"
 #include"rtlsdr.h"
 #include"serial.h"
+#include"util.h"
 
 #include<assert.h>
 #include<fcntl.h>

--- a/src/wmbus_rtlwmbus.cc
+++ b/src/wmbus_rtlwmbus.cc
@@ -23,6 +23,7 @@
 #include"rtlsdr.h"
 #include"serial.h"
 #include"shell.h"
+#include"util.h"
 
 #include<assert.h>
 #include<algorithm>

--- a/src/wmbus_xmqtty.cc
+++ b/src/wmbus_xmqtty.cc
@@ -22,6 +22,7 @@
 #include"meters.h"
 #include"drivers.h"
 #include"xmq.h"
+#include"util.h"
 
 #include<pthread.h>
 #include<semaphore.h>


### PR DESCRIPTION
Removing util.h from translatebits.h to decouple the code further.