### PR TITLE
Add --addrawfield option to include raw hex frame in JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ into human readable:
 or into csv:
 `MyTapWater;33225544;123.529;0;2024-03-03 19:36:45`
 
-or into json:
+or into json (with `--addrawfield` the raw hex frame is also included):
 ```json
 {
     "_":"telegram",
@@ -27,7 +27,8 @@ or into json:
     "id":"33225544",
     "max_flow_m3h":0,
     "total_m3":123.529,
-    "timestamp":"2024-03-03T18:37:00Z"
+    "timestamp":"2024-03-03T18:37:00Z",
+    "_raw":"2e44931578563412330389a2000000"
 }
 ```
 
@@ -285,6 +286,34 @@ printed by libmbus after doing a bus scan, ie `100002842941011B` which is equiva
 
 When matching all meters from the command line you can use `ANYID` instead of `*` to avoid shell quotes.
 
+# Add the raw hex telegram field to JSON output
+
+You can include the full raw telegram as a hexadecimal string in
+every JSON output by setting `addrawfield=true` in either the
+global config file, the meter config file, or using `--addrawfield`
+on the command line.
+
+Meter config file:
+```ini
+name=MyTapWater
+id=12345678
+key=00112233445566778899AABBCCDDEEFF
+driver=multical21
+addrawfield=true
+```
+
+Global config file (`wmbusmeters.conf`):
+```ini
+addrawfield=true
+```
+
+Command line:
+```shell
+wmbusmeters --addrawfield ...
+```
+
+When enabled, a `"_raw":"<hex>"` field is appended to the JSON object.
+
 # Add static and calculated fields to the output
 
 You can add the static json data `"address":"RoadenRd 456","city":"Stockholm"` to every json message with the
@@ -508,6 +537,7 @@ As {options} you can use:
     --oneshot wait for an update from each meter, then quit
     --overridedevice=<device> override device in config files. Use only in combination with --useconfig= option
     --ppjson pretty print the json
+    --addrawfield add the raw hex telegram as "_raw" field in every JSON output
     --pollinterval=<time> time between polling of meters, must be set to get polling.
     --resetafter=<time> reset the wmbus dongle regularly, default is 23h
     --selectfields=id,timestamp,total_m3 select only these fields to be printed (--listfields=<meter> to list available fields)
@@ -849,6 +879,8 @@ wmbusmeters --shell="psql waterreadings -c \"insert into readings values ('\$MET
 (It is much easier to add shell commands in the conf file since you do not need to quote the quotes.)
 
 You can have multiple shell commands and they will be executed in the order you gave them on the command line.
+
+
 
 To list the shell env variables available for a meter, run `wmbusmeters --listenvs=multical21` which outputs:
 

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -335,6 +335,12 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             i++;
             continue;
         }
+        if (!strcmp(argv[i], "--addrawfield"))
+        {
+            c->add_raw_field = true;
+            i++;
+            continue;
+        }
         if (!strncmp(argv[i], "--format=", 9))
         {
             if (!strcmp(argv[i]+9, "json"))

--- a/src/config.cc
+++ b/src/config.cc
@@ -95,6 +95,7 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
     vector<string> extra_constant_fields;
     vector<string> extra_calculated_fields;
     vector<string> selected_fields;
+    bool meter_add_raw_field = false;
 
     debug("(config) loading meter file %s\n", file.c_str());
 
@@ -195,6 +196,12 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
             }
             selected_fields = splitString(p.second, ',');
         }
+        else if (p.first == "addrawfield")
+        {
+            if (p.second == "true") meter_add_raw_field = true;
+            else if (p.second == "false") meter_add_raw_field = false;
+            else warning("addrawfield should be true or false, not \"%s\"\n", p.second.c_str());
+        }
         else if (startsWith(p.first, "json_") ||
                 startsWith(p.first, "field_"))
         {
@@ -256,6 +263,7 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
             mi.shells = telegram_shells;
             mi.new_meter_shells = new_meter_shells;
             mi.selected_fields = selected_fields;
+            mi.add_raw_field = meter_add_raw_field;
             c->meters.push_back(mi);
         }
     }
@@ -359,6 +367,21 @@ void handleIgnoreDuplicateTelegrams(Configuration *c, string value)
     }
     else {
         warning("ignoreduplicates should be either true or false, not \"%s\"\n", value.c_str());
+    }
+}
+
+void handleAddRawField(Configuration *c, string value)
+{
+    if (value == "true")
+    {
+        c->add_raw_field = true;
+    }
+    else if (value == "false")
+    {
+        c->add_raw_field = false;
+    }
+    else {
+        warning("addrawfield should be either true or false, not \"%s\"\n", value.c_str());
     }
 }
 
@@ -816,6 +839,7 @@ shared_ptr<Configuration> loadConfiguration(string root, ConfigOverrides overrid
         else if (p.first == "separator") handleSeparator(c, p.second);
         else if (p.first == "logtimestamps") handleLogTimestamps(c, p.second);
         else if (p.first == "selectfields") handleSelectedFields(c, p.second);
+        else if (p.first == "addrawfield") handleAddRawField(c, p.second);
         else if (p.first == "shell") handleShell(c, p.second);
         else if (p.first == "resetafter") handleResetAfter(c, p.second);
         else if (p.first == "metershell") handleMeterShell(c, p.second);

--- a/src/config.h
+++ b/src/config.h
@@ -100,6 +100,7 @@ struct Configuration
     std::string logfile;
     bool json {};
     bool pretty_print_json {};
+    bool add_raw_field {};
     int  pollinterval {}; // Time between polling of mbus meters.
     IdentityMode identity_mode {}; // How to group meters identities into state objects.
     bool fields {};

--- a/src/main.cc
+++ b/src/main.cc
@@ -174,6 +174,7 @@ shared_ptr<Printer> create_printer(Configuration *config)
 {
     return shared_ptr<Printer>(new Printer(config->json,
                                            config->pretty_print_json,
+                                           config->add_raw_field,
                                            config->fields,
                                            config->separator, config->meterfiles, config->meterfiles_dir,
                                            config->use_logfile, config->logfile,

--- a/src/metermanager.cc
+++ b/src/metermanager.cc
@@ -488,7 +488,7 @@ public:
                 vector<string> envs, more_json, selected_fields;
 
                 meter->printMeter(&t, &hr, &fields, '\t', &json,
-                                  &envs, &more_json, &selected_fields, true);
+                                  &envs, &more_json, &selected_fields, true, false);
                 if (k % 100 == 0) fprintf(stderr, ".");
             }
 
@@ -522,7 +522,7 @@ public:
         vector<string> envs, more_json, selected_fields;
 
         meter->printMeter(&t, &hr, &fields, '\t', &json,
-                          &envs, &more_json, &selected_fields, true);
+                          &envs, &more_json, &selected_fields, true, false);
 
         if (auto_driver == "")
         {

--- a/src/meters.cc
+++ b/src/meters.cc
@@ -2358,7 +2358,8 @@ void MeterCommonImplementation::printMeter(Telegram *t,
                                            vector<string> *envs,
                                            vector<string> *extra_constant_fields,
                                            vector<string> *selected_fields,
-                                           bool pretty_print_json)
+                                           bool pretty_print_json,
+                                           bool add_raw_field)
 {
     bool first = !t->meter->hasReceivedFirstTelegram();
 
@@ -2401,6 +2402,13 @@ void MeterCommonImplementation::printMeter(Telegram *t,
     string s;
     s += "{"+newline;
     s += indent+"\"_\":\"telegram\","+newline;
+    if (add_raw_field)
+    {
+        vector<uchar> raw_frame;
+        t->extractFrame(&raw_frame);
+        if (!t->original.empty()) raw_frame = t->original;
+        s += indent+"\"_raw\":\""+bin2hex(raw_frame)+"\","+newline;
+    }
     s += indent+"\"media\":\""+media+"\","+newline;
     s += indent+"\"meter\":\""+driverName().str()+"\","+newline;
     s += indent+"\"name\":\""+name()+"\","+newline;

--- a/src/meters.h
+++ b/src/meters.h
@@ -100,6 +100,7 @@ struct MeterInfo
     std::vector<std::string> extra_constant_fields; // Additional static fields that are added to each message.
     std::vector<std::string> extra_calculated_fields; // Additional field calculated using formulas.
     std::vector<std::string> selected_fields; // Usually set to the default fields, but can be override in meter config.
+    bool add_raw_field {}; // When true, include "_raw" (raw hex frame) in JSON output.
 
     // If this is a meter that needs to be polled.
     int    poll_interval; // Poll every x seconds.
@@ -490,7 +491,8 @@ struct Meter
                             std::vector<std::string> *envs,
                             std::vector<std::string> *more_json,
                             std::vector<std::string> *selected_fields,
-                            bool pretty_print_json) = 0;
+                            bool pretty_print_json,
+                            bool add_raw_field) = 0;
 
     // The handleTelegram expects an input_frame where the DLL crcs have been removed.
     // Returns true of this meter handled this telegram!

--- a/src/meters_common_implementation.h
+++ b/src/meters_common_implementation.h
@@ -186,7 +186,8 @@ protected:
                     std::vector<std::string> *envs,
                     std::vector<std::string> *more_json, // Add this json "key"="value" strings.
                     std::vector<std::string> *selected_fields, // Only print these fields.
-                    bool pretty_print); // Insert newlines and indentation.
+                    bool pretty_print, // Insert newlines and indentation.
+                    bool add_raw_field); // Include "_raw" hex frame in JSON output.
     // Json fields include all values except timestamp_ut, timestamp_utc, timestamp_lt
     // since Json is assumed to be decoded by a program and the current timestamp which is the
     // same as timestamp_utc, can always be decoded/recoded into local time or a unix timestamp.

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-Printer::Printer(bool json, bool pretty_print_json, bool fields, char separator,
+Printer::Printer(bool json, bool pretty_print_json, bool add_raw_field, bool fields, char separator,
                  bool use_meterfiles, string &meterfiles_dir,
                  bool use_logfile, string &logfile,
                  vector<string> new_meter_shell_cmdlines,
@@ -33,6 +33,7 @@ Printer::Printer(bool json, bool pretty_print_json, bool fields, char separator,
 {
     json_ = json;
     pretty_print_json_ = pretty_print_json;
+    add_raw_field_ = add_raw_field;
     fields_ = fields;
     separator_ = separator;
     use_meterfiles_ = use_meterfiles;
@@ -54,7 +55,7 @@ void Printer::print(Telegram *t, Meter *meter,
     vector<string> envs;
     bool printed = false;
 
-    meter->printMeter(t, &human_readable, &fields, separator_, &json, &envs, more_json, selected_fields, pretty_print_json_);
+    meter->printMeter(t, &human_readable, &fields, separator_, &json, &envs, more_json, selected_fields, pretty_print_json_, add_raw_field_);
 
     if (!meter->hasReceivedFirstTelegram())
     {

--- a/src/printer.h
+++ b/src/printer.h
@@ -21,6 +21,7 @@
 struct Printer {
     Printer(bool json,
             bool pretty_print_json,
+            bool add_raw_field,
             bool fields,
             char separator,
             bool meterfiles, std::string &meterfiles_dir,
@@ -35,7 +36,7 @@ struct Printer {
 
     private:
 
-    bool json_, pretty_print_json_, fields_;
+    bool json_, pretty_print_json_, add_raw_field_, fields_;
     bool use_meterfiles_;
     std::string meterfiles_dir_;
     bool use_logfile_;

--- a/src/wmbus_socket.cc
+++ b/src/wmbus_socket.cc
@@ -400,7 +400,7 @@ void WMBusSocket::handleDecode(XMQDoc *doc, const string &line)
 
     string hr, fields, json;
     vector<string> envs, more_json, selected_fields;
-    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, false);
+    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, false, false);
 
     int content_bytes = 0, understood_bytes = 0;
     out_telegram.analyzeParse(OutputFormat::NONE, &content_bytes, &understood_bytes);

--- a/src/wmbus_xmqtty.cc
+++ b/src/wmbus_xmqtty.cc
@@ -374,7 +374,7 @@ void WMBusXmqTTY::processLine(const string &line)
     // Generate output
     string hr, fields, json;
     vector<string> envs, more_json, selected_fields;
-    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, false);
+    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, false, false);
 
     // Check parse quality - how much of the content was understood (in bytes)
     int content_bytes = 0, understood_bytes = 0;

--- a/test.sh
+++ b/test.sh
@@ -155,6 +155,9 @@ if [ "$?" != "0" ]; then RC="1"; fi
 tests/test_additional_json.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 
+tests/test_addrawfield.sh $PROG
+if [ "$?" != "0" ]; then RC="1"; fi
+
 tests/test_addresses.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 

--- a/tests/test_addrawfield.sh
+++ b/tests/test_addrawfield.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+PROG="$1"
+TEST=testoutput
+mkdir -p $TEST
+
+TESTNAME="Test addrawfield feature"
+TESTRESULT="ERROR"
+
+# Use a known unencrypted telegram (lansenpu pulse counter)
+HEX="234433300602010014007a8e0400002f2f0efd3a1147000000008e40fd3a341200000000"
+
+# Test 1: Without --addrawfield, _raw should NOT be present
+$PROG --silent --format=json $HEX MyCounter auto 00010206 NOKEY 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_no_raw.txt
+HAS_RAW=$(jq 'has("_raw")' $TEST/test_no_raw.txt)
+if [ "$HAS_RAW" != "false" ]; then
+    echo "ERROR: _raw present without --addrawfield"
+    exit 1
+fi
+echo "OK: Without --addrawfield, _raw is absent"
+
+# Test 2: With --addrawfield, _raw should be present and non-empty
+$PROG --silent --format=json --addrawfield $HEX MyCounter auto 00010206 NOKEY 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_with_raw.txt
+HAS_RAW=$(jq 'has("_raw")' $TEST/test_with_raw.txt)
+RAW_VALUE=$(jq -r '._raw' $TEST/test_with_raw.txt)
+if [ "$HAS_RAW" != "true" ]; then
+    echo "ERROR: _raw absent with --addrawfield"
+    exit 1
+fi
+if [ -z "$RAW_VALUE" ] || [ "$RAW_VALUE" = "null" ]; then
+    echo "ERROR: _raw is empty"
+    exit 1
+fi
+echo "OK: With --addrawfield, _raw is present"
+
+# Test 3: Verify _raw value matches the input hex (bin2hex outputs uppercase)
+EXPECTED=$(echo "$HEX" | tr '[:lower:]' '[:upper:]')
+if [ "$RAW_VALUE" != "$EXPECTED" ]; then
+    echo "ERROR: _raw value mismatch. Expected $EXPECTED, got $RAW_VALUE"
+    exit 1
+fi
+echo "OK: _raw value matches input hex"
+
+# Test 4: With --ppjson --addrawfield, _raw should be properly formatted
+$PROG --silent --format=json --ppjson --addrawfield $HEX MyCounter auto 00010206 NOKEY 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_pp_raw.txt
+HAS_RAW=$(jq 'has("_raw")' $TEST/test_pp_raw.txt)
+if [ "$HAS_RAW" != "true" ]; then
+    echo "ERROR: --ppjson --addrawfield missing _raw"
+    exit 1
+fi
+echo "OK: --ppjson --addrawfield produces valid output"
+
+echo "OK: $TESTNAME"
+exit 0


### PR DESCRIPTION
Introduces an opt-in _raw field containing the full raw telegram as a hex string, placed right after the _ key in the JSON output.

- Add add_raw_field flag to Configuration, MeterInfo, and Printer
- Parse --addrawfield CLI flag, addrawfield=true in config files
- Thread flag through Printer::print -> printMeter
- Emit "_raw":"<hex>" as the second JSON key when enabled
- Add tests verifying presence, absence, and value correctness
- Update README with documentation and examples