### PR TITLE
feat: implement --analyze=json output

### DIFF
--- a/src/testinternals.cc
+++ b/src/testinternals.cc
@@ -87,6 +87,7 @@ bool verbose_ = false;
     X(formulas_stringinterpolation)             \
     X(formulas_rounding)                        \
     X(formulas_extended_ops)                    \
+    X(analyze_json)
 
 #define X(t) void test_##t();
 LIST_OF_TESTS
@@ -3188,4 +3189,25 @@ void test_dynamic_loading()
         printf("ERROR in dynamic loading got %s but expected %s!\n",
                toString(vr), toString(VIFRange::DateTime));
     }
+}
+
+void test_analyze_json()
+{
+    vector<Explanation> es;
+    es.push_back(Explanation(0, 4, "header", KindOfData::PROTOCOL, Understanding::NONE));
+    es.emplace_back(10, 3, "a\"b", KindOfData::CONTENT, Understanding::FULL);
+    es.back().ixml_parse = "p";
+
+    string j = renderAnalysisAsJson(es);
+
+    assert(j.find("TODO") == string::npos);
+    assert(j.front() == '[');
+    assert(j.find("\"pos\": 0") != string::npos);
+    assert(j.find("\"len\": 4") != string::npos);
+    assert(j.find("\"kind\": \"PROTOCOL\"") != string::npos);
+    assert(j.find("\"understanding\": \"NONE\"") != string::npos);
+    assert(j.find("\"pos\": 10") != string::npos);
+    assert(j.find("\"kind\": \"CONTENT\"") != string::npos);
+    assert(j.find("\"understanding\": \"FULL\"") != string::npos);
+    assert(j.find("a\\\"b") != string::npos);
 }

--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -44,6 +44,8 @@
 
 #include<deque>
 #include<algorithm>
+#include<iomanip>
+#include<sstream>
 
 using namespace std;
 
@@ -2415,9 +2417,59 @@ string renderAnalysisAsText(vector<Explanation> &explanations, OutputFormat of)
     return s;
 }
 
+static string escapeJson(const string &input)
+{
+    ostringstream ss;
+    for (char c : input)
+    {
+        switch (c)
+        {
+        case '"':  ss << "\\\""; break;
+        case '\\': ss << "\\\\"; break;
+        case '\b': ss << "\\b"; break;
+        case '\f': ss << "\\f"; break;
+        case '\n': ss << "\\n"; break;
+        case '\r': ss << "\\r"; break;
+        case '\t': ss << "\\t"; break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20)
+            {
+                ss << "\\u" << hex << setw(4) << setfill('0') << (int)(unsigned char)c;
+            }
+            else
+            {
+                ss << c;
+            }
+        }
+    }
+    return ss.str();
+}
+
 string renderAnalysisAsJson(vector<Explanation> &explanations)
 {
-    return "{ \"TODO\": true }\n";
+    string s = "[\n";
+    for (size_t i = 0; i < explanations.size(); i++)
+    {
+        const auto &p = explanations[i];
+        const char *kind_str = (p.kind == KindOfData::PROTOCOL) ? "PROTOCOL" : "CONTENT";
+        const char *under_str =
+            p.understanding == Understanding::NONE       ? "NONE"       :
+            p.understanding == Understanding::ENCRYPTED  ? "ENCRYPTED"  :
+            p.understanding == Understanding::COMPRESSED ? "COMPRESSED" :
+            p.understanding == Understanding::PARTIAL    ? "PARTIAL"    :
+                                                          "FULL";
+
+        s += "  {\n";
+        s += tostrprintf("    \"pos\": %d,\n", p.pos);
+        s += tostrprintf("    \"len\": %d,\n", p.len);
+        s += "    \"info\": \"" + escapeJson(p.info) + "\",\n";
+        s += "    \"ixml_parse\": \"" + escapeJson(p.ixml_parse) + "\",\n";
+        s += "    \"kind\": \"" + string(kind_str) + "\",\n";
+        s += "    \"understanding\": \"" + string(under_str) + "\"\n";
+        s += (i + 1 < explanations.size()) ? "  },\n" : "  }\n";
+    }
+    s += "]\n";
+    return s;
 }
 
 string Telegram::analyzeParse(OutputFormat format, int *content_length, int *understood_content_length)

--- a/src/wmbus.h
+++ b/src/wmbus.h
@@ -308,6 +308,8 @@ struct Explanation
         pos(p), len(l), info(i), kind(k), understanding(u) {}
 };
 
+std::string renderAnalysisAsJson(std::vector<Explanation> &explanations);
+
 struct Meter;
 
 struct Telegram


### PR DESCRIPTION
## What

`wmbusmeters --analyze=json:<driver>:<key>` (the JSON output mode of `--analyze`) returned a hard-coded placeholder:

```c
string renderAnalysisAsJson(vector<Explanation> &explanations)
{
    return "{ \"TODO\": true }\n";
}
```

This replaces the placeholder with the actual per-byte-range explanations as a JSON array:

```json
[
  { "pos": 0, "len": 1, "info": "18 length (24 bytes)", "ixml_parse": "", "kind": "PROTOCOL", "understanding": "FULL" },
  ...
]
```

String fields (`info`, `ixml_parse`) are JSON-escaped.

## How (TDD)

- `5c2ab5ae` adds a failing unit test (`test_analyze_json` in `src/testinternals.cc`) that asserts the array shape, the `pos`/`len`/`kind`/`understanding` fields, and that an embedded `"` in `info` is escaped. Against the stub it aborts on `assert(j.find("TODO") == string::npos)`.
- `823c84af` implements `renderAnalysisAsJson` + a small `escapeJson` helper and declares the function in `wmbus.h` so the test (and the existing `Telegram::analyzeParse` JSON path) can reach it.

```
./build/testinternals analyze_json   -> Test analyze_json
./test.sh build/wmbusmeters          -> All tests ok!
```

End-to-end, on a sample telegram:
```
$ wmbusmeters --analyze=json 1844AE4C...2B0000
Auto driver    : iperl
...
[
  { "pos": 0, "len": 1, "info": "18 length (24 bytes)", "ixml_parse": "", "kind": "PROTOCOL", "understanding": "FULL" },
  ...
]
```

## Scope

This is split out from #2007, which bundled several unrelated changes. `renderAnalysisAsJson` is the only piece not already covered elsewhere. The CP32/CP48/Type-G date-time work is covered by #1903.