### PR TITLE
fix: add DEFECT status support to tsd2 driver

### DIFF
--- a/drivers/src/tsd2.xmq
+++ b/drivers/src/tsd2.xmq
@@ -52,6 +52,11 @@ driver {
                     value = 1
                     test  = Set
                 }
+                map {
+                    name  = DEFECT
+                    value = 128
+                    test  = Set
+                }
             }
         }
         field {
@@ -104,6 +109,13 @@ driver {
             telegram = 294468506935639176F0A0_019F2782290060822900000401D6311AF93E1BF93E008DC3009ED4000FE500
             json     = '{"_":"telegram","media":"smoke detector","meter":"tsd2","name":"Smokey","id":"91633569","status":"SMOKE","prev_date":"2019-12-31","timestamp":"1111-11-11T11:11:11Z"}'
             fields   = 'Smokey;91633569;SMOKE;2019-12-31;1111-11-11 11:11.11'
+        }
+        test {
+            comment  = 'Status DEFECT with date'
+            args     = 'Smokey tsd2 91633569 NOKEY'
+            telegram = 294468506935639176F0A0_809F2782290060822900000401D6311AF93E1BF93E008DC3009ED4000FE580
+            json     = '{"_":"telegram","media":"smoke detector","meter":"tsd2","name":"Smokey","id":"91633569","status":"DEFECT","prev_date":"2019-12-31","timestamp":"1111-11-11T11:11:11Z"}'
+            fields   = 'Smokey;91633569;DEFECT;2019-12-31;1111-11-11 11:11.11'
         }
         test {
             comment  = 'Invalid status byte.'


### PR DESCRIPTION
I just noticed in my local testing, that one of the Techem Smoke Detectors I was receiving reported `STATUS_80`, which - according to https://github.com/wmbusmeters/wmbusmeters/issues/200 - should indicate `DEFECT` instead.
