### PR TITLE
Add support for Custom C/T mode in IU891A (link mode 07)

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ As {options} you can use:
     --ignoreduplicates=<bool> ignore duplicate telegrams, remember the last 10 telegrams
     --field_xxx=yyy always add "xxx"="yyy" to the json output and add shell env METER_xxx=yyy (--json_xxx=yyy also works)
     --license print GPLv3+ license
-    --listento=<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes
+    --listento=<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes, or cct for iU891A Custom C/T mode
     --listento=<mode>,<mode> listen to more than one link mode at the same time, assuming the dongle supports it
     --listenvs=<meter_driver> list the env variables available for the given meter driver
     --listfields=<meter_driver> list the fields selectable for the given meter driver

--- a/src/short_manual.h
+++ b/src/short_manual.h
@@ -46,7 +46,7 @@ As {options} you can use:
     --ignoreduplicates=<bool> ignore duplicate telegrams, remember the last 10 telegrams
     --field_xxx=yyy always add "xxx"="yyy" to the json output and add shell env METER_xxx=yyy (--json_xxx=yyy also works)
     --license print GPLv3+ license
-    --listento=<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes
+    --listento=<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes, or cct for iU891A Custom C/T mode
     --listento=<mode>,<mode> listen to more than one link mode at the same time, assuming the dongle supports it
     --listenvs=<meter_driver> list the env variables available for the given meter driver
     --listfields=<meter_driver> list the fields selectable for the given meter driver

--- a/src/testinternals.cc
+++ b/src/testinternals.cc
@@ -27,6 +27,7 @@
 #include"translatebits.h"
 #include"util.h"
 #include"wmbus.h"
+#include"wmbus_iu891a.h"
 #include"dvparser.h"
 #include"xmq.h"
 
@@ -484,6 +485,23 @@ void test_devices()
 
 void test_linkmodes()
 {
+    LinkModeSet cct = parseLinkModes("cct");
+    assert(cct.has(LinkMode::CCT));
+    assert(cct.hr() == "cct");
+    assert(toLinkMode("cct") == LinkMode::CCT);
+    assert(isLinkModeOption("--cct") == LinkMode::CCT);
+    assert(!strcmp(toString(LinkMode::CCT), "cct"));
+    assert(cct.asBits() == CCT_bit);
+    assert(countSetBits(cct.asBits()) == 1);
+    assert(setupIMSTBusDeviceToReceiveTelegrams(cct) == LINK_MODE_CUSTOM_CT);
+
+    LinkModeSet all;
+    all.setAll();
+    assert(all.has(LinkMode::CCT));
+
+    LinkModeSet ct = parseLinkModes("c1,t1");
+    assert(setupIMSTBusDeviceToReceiveTelegrams(ct) == LINK_MODE_CT);
+
     /*
     LinkModeCalculationResult lmcr;
     auto manager = createSerialCommunicationManager(0, false);

--- a/src/util.cc
+++ b/src/util.cc
@@ -617,7 +617,7 @@ void addYears(struct tm *date, int y)
     return addMonths(date, 12*y);
 }
 
-int countSetBits(int v)
+int countSetBits(uint64_t v)
 {
     int n = 0;
     while (v)

--- a/src/util.h
+++ b/src/util.h
@@ -145,7 +145,7 @@ std::string eatToSkipWhitespace(std::vector<char> &v, std::vector<char>::iterato
 void trimWhitespace(std::string *s);
 
 // Count the number of 1:s in the binary number v.
-int countSetBits(int v);
+int countSetBits(uint64_t v);
 
 bool startsWith(const std::string &s, const char *prefix);
 bool startsWith(const std::string &s, std::string &prefix);

--- a/src/wmbus/link_mode.h
+++ b/src/wmbus/link_mode.h
@@ -67,7 +67,8 @@
     X(R2h,r2h,--r2h,   (1UL<<28))    \
     X(R2i,r2i,--r2i,   (1UL<<29))    \
     X(R2j,r2j,--r2j,   (1UL<<30))    \
-    X(LORA,lora,--lora,   (1UL<<31))    \
+    X(LORA,lora,--lora,   (UINT64_C(1)<<31))    \
+    X(CCT,cct,--cct,      (UINT64_C(1)<<32))    \
     X(UNKNOWN,unknown,----,0x0UL)
 
 enum class LinkMode {
@@ -112,9 +113,9 @@ struct LinkModeSet
     // Clear the set to empty.
     void clear() { set_ = 0; }
     // Mark set as all linkmodes!
-    void setAll() { set_ = (int)LinkMode::Any; }
+    void setAll() { set_ = Any_bit; }
     // For bit counting etc.
-    int asBits() { return set_; }
+    uint64_t asBits() { return set_; }
 
     // Return a human readable string.
     std::string hr();

--- a/src/wmbus_iu891a.cc
+++ b/src/wmbus_iu891a.cc
@@ -178,6 +178,10 @@ struct Config_IU891A
         {
             link_modes.addLinkMode(LinkMode::C1);
         }
+        else if (c == LINK_MODE_CUSTOM_CT)
+        {
+            link_modes.addLinkMode(LinkMode::CCT);
+        }
         option_bits = bytes[i+1]<<8 | bytes[i+0];
         i += 2;
         ui_option_bits = bytes[i+1]<<8 | bytes[i+0];
@@ -253,7 +257,8 @@ struct WMBusIU891A : public BusDeviceCommonImplementation
             S1_bit |
             S1m_bit |
             T1_bit |
-            T2_bit;
+            T2_bit |
+            CCT_bit;
     }
 
     int numConcurrentLinkModes()
@@ -432,7 +437,11 @@ void WMBusIU891A::deviceReset()
 
 uchar setupIMSTBusDeviceToReceiveTelegrams(LinkModeSet lms)
 {
-    if (lms.has(LinkMode::C1) && lms.has(LinkMode::T1))
+    if (lms.has(LinkMode::CCT))
+    {
+        return LINK_MODE_CUSTOM_CT;
+    }
+    else if (lms.has(LinkMode::C1) && lms.has(LinkMode::T1))
     {
         return LINK_MODE_CT;
     }

--- a/src/wmbus_iu891a.h
+++ b/src/wmbus_iu891a.h
@@ -10,6 +10,9 @@
 #define LINK_MODE_CT 3
 #define LINK_MODE_C 5
 #define LINK_MODE_ENHANCED_T 6
+#define LINK_MODE_CUSTOM_CT 7
+
+uchar setupIMSTBusDeviceToReceiveTelegrams(LinkModeSet lms);
 
 #define DEVMGMT_MSG_PING_REQ 0x01
 #define DEVMGMT_MSG_PING_RSP 0x02

--- a/wmbusmeters.1
+++ b/wmbusmeters.1
@@ -61,7 +61,7 @@ Add :verbose to any analyze to get more verbose analyze output.
 
 \fB\--license\fR print GPLv3+ license
 
-\fB\--listento=\fR<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes
+\fB\--listento=\fR<mode> listen to one of the c1,t1,s1,s1m,n1a-n1f link modes, or cct for iU891A Custom C/T mode
 
 \fB\--listento=\fR<mode>,<mode> listen to more than one link mode at the same time, assuming the dongle supports it
 


### PR DESCRIPTION
Implements #2049.
Tested successfully with sensostar heat meter which didn't work in c1 (link mode 05). My waterstarm water meters still work in cct (link mode 07)